### PR TITLE
Be more sensible in the wavefront problem size

### DIFF
--- a/examples/wavefront/wavefront-df.cc
+++ b/examples/wavefront/wavefront-df.cc
@@ -260,8 +260,8 @@ int main(int argc, char** argv) {
   int n_rows, n_cols, B;
   int n_brows, n_bcols;
 
-  n_rows = n_cols = 8192;
-  B = 128;
+  n_rows = n_cols = 2048;
+  B = 64;
   bool verify = true;
 
   n_brows = (n_rows / B) + (n_rows % B > 0);

--- a/examples/wavefront/wavefront-wf.cc
+++ b/examples/wavefront/wavefront-wf.cc
@@ -146,8 +146,8 @@ auto make_wavefront(std::shared_ptr<double> m, const funcT& func, Edge<Key, Cont
 
 int main(int argc, char** argv) {
   ttg_initialize(argc, argv, -1);
-  M = N = 16384;
-  B = 128;
+  M = N = 2048;
+  B = 64;
 
   MB = (M / B) + (M % B > 0);
   NB = (N / B) + (N % B > 0);

--- a/examples/wavefront/wavefront-wf2.cc
+++ b/examples/wavefront/wavefront-wf2.cc
@@ -274,8 +274,8 @@ int main(int argc, char** argv) {
   int n_rows, n_cols, B;
   int n_brows, n_bcols;
 
-  n_rows = n_cols = 16384;
-  B = 128;
+  n_rows = n_cols = 2048;
+  B = 64;
 
   n_brows = (n_rows / B) + (n_rows % B > 0);
   n_bcols = (n_cols / B) + (n_cols % B > 0);


### PR DESCRIPTION
We shouldn't require 2GB per matrix in the wavefront, let's be reasonable here.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>