### PR TITLE
Add priority mapping to Ops

### DIFF
--- a/examples/potrf/potrf_pdc.cc
+++ b/examples/potrf/potrf_pdc.cc
@@ -941,6 +941,18 @@ int main(int argc, char **argv)
   auto op_result = make_result(A, result);
   op_result->set_keymap(keymap2);
 
+
+  /* Priorities taken from DPLASMA */
+  auto nt = A.cols();
+  op_potrf->set_priomap([&](const Key1& key){ return ((nt - key.K) * (nt - key.K) * (nt - key.K)); });
+  op_trsm->set_priomap([&](const Key2& key) { return ((nt - key.I) * (nt - key.I) * (nt - key.I)
+                                                      + 3 * ((2 * nt) - key.J - key.I - 1) * (key.I - key.J)); });
+  op_syrk->set_priomap([&](const Key2& key) { return ((nt - key.I) * (nt - key.I) * (nt - key.I)
+                                                      + 3 * (key.I - key.J)); });
+  op_gemm->set_priomap([&](const Key3& key) { return ((nt - key.I) * (nt - key.I) * (nt - key.I)
+                                                      + 3 * ((2 * nt) - key.I - key.J - 3) * (key.I - key.J)
+                                                      + 6 * (key.I - key.K)); });
+
   auto connected = make_graph_executable(op_init.get());
   assert(connected);
   TTGUNUSED(connected);

--- a/ttg/ttg/base/keymap.h
+++ b/ttg/ttg/base/keymap.h
@@ -30,6 +30,20 @@ namespace ttg {
       int world_size;
     };
 
+
+    /// the default priority map implementation
+    template <typename keyT>
+    struct default_priomap_impl {
+      default_priomap_impl() = default;
+
+      template <typename Key = keyT>
+      std::enable_if_t<!meta::is_void_v<Key>,int>
+      operator()(const Key &key) const { return 0; }
+      template <typename Key = keyT>
+      std::enable_if_t<meta::is_void_v<Key>,int>
+      operator()() const { return 0; }
+    };
+
   }  // namespace detail
 
 } // namespace ttg

--- a/ttg/ttg/world.h
+++ b/ttg/ttg/world.h
@@ -37,6 +37,12 @@ namespace ttg {
         default_keymap(ttg::World& world) : ttg::detail::default_keymap_impl<keyT>(world.size()) {}
       };
 
+      template <typename keyT>
+      struct default_priomap : ttg::detail::default_priomap_impl<keyT> {
+       public:
+        default_priomap() = default;
+      };
+
       template<typename WorldImplT>
       std::list<WorldImplT*>&
       world_registry_accessor() {


### PR DESCRIPTION
Allows applications to specify a priority map mapping keys to priorities.
The priorities are a hint to the scheduler and may not be supported by
all backends (currently only the PaRSEC backend supports them).

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>