### PR TITLE
fix non-POSIX-standard function def in shell scripts

### DIFF
--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -75,7 +75,7 @@ RUN echo "\e[92mDone! For info on how to use the image refer to $ABSDIRNAME/dock
 
 END
 
-function clean_up {
+clean_up() {
   rm -f $disable_aslr Dockerfile
   exit
 }

--- a/bin/docker-travis-build.sh
+++ b/bin/docker-travis-build.sh
@@ -78,7 +78,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD $build /home/travis/_build/$build
 END
 
-function clean_up {
+clean_up() {
   rm -f $setup $build Dockerfile
   exit
 }


### PR DESCRIPTION
The docker-build.sh script failed for me on Ubuntu 20.04 with:
`$ bin/docker-build.sh amd64
bin/docker-build.sh: 78: function: not found`
This is due to the use of non-POSIX-standard bash syntax for function definition, which this patch fixes.