### PR TITLE
PaRSEC backend: rename my_op_t and store key inline

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -195,6 +195,7 @@ namespace ttg_parsec {
     static constexpr const int _PARSEC_TTG_RMA_TAG = 11;  // This TAG should be 'allocated' at the PaRSEC level
 
     ttg::Edge<> m_ctl_edge;
+    int m_rank, m_size;
 
    public:
     static constexpr const int PARSEC_TTG_MAX_AM_SIZE = 1024 * 1024;
@@ -206,6 +207,8 @@ namespace ttg_parsec {
       parsec_ce.tag_register(_PARSEC_TTG_TAG, &detail::static_unpack_msg, this, PARSEC_TTG_MAX_AM_SIZE);
       parsec_ce.tag_register(_PARSEC_TTG_RMA_TAG, &detail::get_remote_complete_cb, this, 128);
 
+      MPI_Comm_size(comm(), &m_size);
+      MPI_Comm_rank(comm(), &m_rank);
       create_tpool();
     }
 
@@ -257,17 +260,12 @@ namespace ttg_parsec {
     constexpr int parsec_ttg_tag() const { return _PARSEC_TTG_TAG; }
     constexpr int parsec_ttg_rma_tag() const { return _PARSEC_TTG_RMA_TAG; }
 
-    virtual int size() const override {
-      int size;
-
-      MPI_Comm_size(comm(), &size);
-      return size;
+    virtual int size() const override final {
+      return m_size;
     }
 
-    virtual int rank() const override {
-      int rank;
-      MPI_Comm_rank(comm(), &rank);
-      return rank;
+    virtual int rank() const override final {
+      return m_rank;
     }
 
     MPI_Comm comm() const { return MPI_COMM_WORLD; }

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -388,7 +388,7 @@ namespace ttg_parsec {
 
       inline
       parsec_ttg_op_base_t() {
-        //PARSEC_OBJ_CONSTRUCT(&this->parsec_task, parsec_task_t);
+        PARSEC_OBJ_CONSTRUCT(&this->parsec_task, parsec_task_t);
       }
     };
 

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1479,12 +1479,13 @@ namespace ttg_parsec {
       using valueT = typename std::tuple_element<i, input_values_full_tuple_type>::type;
       auto world = ttg_default_execution_context();
       int rank = world.rank();
-
-      bool have_remote = keylist.end() != std::find_if(keylist.begin(), keylist.end(),
-                                                      [&](const Key& key){
-                                                        return keymap(key) != rank;
-                                                      });
-
+      bool have_remote = false;
+      if (world.size() > 1) {
+        have_remote = keylist.end() != std::find_if(keylist.begin(), keylist.end(),
+                                                    [&](const Key& key){
+                                                      return keymap(key) != rank;
+                                                    });
+      }
       if (have_remote) {
         std::vector<Key> keylist_sorted(keylist.begin(), keylist.end());
 
@@ -1573,11 +1574,13 @@ namespace ttg_parsec {
       using valueT = typename std::tuple_element<i, input_values_full_tuple_type>::type;
       auto world = ttg_default_execution_context();
       int rank = world.rank();
-      bool have_remote = keylist.end() != std::find_if(keylist.begin(), keylist.end(),
-                                                      [&](const Key& key){
-                                                        return keymap(key) != rank;
-                                                      });
-
+      bool have_remote = false;
+      if (world.size() > 1) {
+        have_remote = keylist.end() != std::find_if(keylist.begin(), keylist.end(),
+                                                    [&](const Key& key){
+                                                      return keymap(key) != rank;
+                                                    });
+      }
       if (have_remote) {
         using decvalueT = std::decay_t<Value>;
 

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -145,9 +145,8 @@ namespace ttg_parsec {
     ttg_data_copy_t*
     find_copy_in_task(parsec_task_t* task, const void *ptr) {
       ttg_data_copy_t* copy = nullptr;
-      int j = -1;
-      if (task != nullptr || ptr != nullptr) {
-        while(++j < MAX_CALL_PARAM_COUNT) {
+      if (task != nullptr && ptr != nullptr) {
+        for (int j = 0; j < MAX_CALL_PARAM_COUNT; ++j) {
           if (NULL != task->data[j].data_in &&
               task->data[j].data_in->device_private == ptr)
           {

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1187,8 +1187,10 @@ namespace ttg_parsec {
             parsec_hash_table_unlock_bucket(&tasks_table, hk);
             parsec_mempool_free(&mempools, newtask);
           }
-        } else if (task->in_data_count == numins-1) {
-          parsec_hash_table_nolock_remove(&tasks_table, hk);
+        } else {
+          if (task->in_data_count == numins-1) {
+            parsec_hash_table_nolock_remove(&tasks_table, hk);
+          }
           parsec_hash_table_unlock_bucket(&tasks_table, hk);
         }
 
@@ -1410,7 +1412,7 @@ namespace ttg_parsec {
         // and give it to the scheduler
         parsec_execution_stream_s *es = world_impl.execution_stream();
         detail::parsec_ttg_op_t<Key> *task = create_new_task(key);
-        task->parsec_task.data[0].data_in = static_cast<ttg_data_copy_t *>(NULL);
+        task->parsec_task.data[0].data_in = nullptr;
         if (tracing()) ttg::print(world.rank(), ":", get_name(), " : ", key, ": creating task");
         world_impl.increment_created();
         if (tracing()) ttg::print(world.rank(), ":", get_name(), " : ", key, ": submitting task for op ");

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -369,7 +369,7 @@ namespace ttg_parsec {
     typedef void (*parsec_static_op_t)(void *);  // static_op will be cast to this type
 
     struct parsec_ttg_op_base_t {
-      parsec_task_t parsec_task;
+      parsec_task_t parsec_task = {0};
       // TODO need to augment PaRSEC backend's my_op_s by stream size info, etc.  ... in_data_count will need to be
       // replaced by something like this
       //  int counter;                            // Tracks the number of arguments set
@@ -378,7 +378,7 @@ namespace ttg_parsec {
       //      stream_size;                        // Expected number of values to receive, only used for streaming
       //      inputs
       //  // (0 = unbounded stream)
-      parsec_hash_table_item_t op_ht_item;
+      parsec_hash_table_item_t op_ht_item = {0};
       int32_t in_data_count = 0;
       parsec_static_op_t function_template_class_ptr[ttg::runtime_traits<ttg::Runtime::PaRSEC>::num_execution_spaces] = {nullptr};
       void *object_ptr = nullptr;

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -370,8 +370,7 @@ namespace ttg_parsec {
     typedef void (*parsec_static_op_t)(void *);  // static_op will be cast to this type
 
     struct parsec_ttg_op_base_t {
-      parsec_task_t parsec_task = {};
-      int32_t in_data_count = 0;
+      parsec_task_t parsec_task;
       // TODO need to augment PaRSEC backend's my_op_s by stream size info, etc.  ... in_data_count will need to be
       // replaced by something like this
       //  int counter;                            // Tracks the number of arguments set
@@ -380,15 +379,17 @@ namespace ttg_parsec {
       //      stream_size;                        // Expected number of values to receive, only used for streaming
       //      inputs
       //  // (0 = unbounded stream)
-      parsec_hash_table_item_t op_ht_item = {};
-      parsec_static_op_t function_template_class_ptr[ttg::runtime_traits<ttg::Runtime::PaRSEC>::num_execution_spaces] = { nullptr };
+      parsec_hash_table_item_t op_ht_item;
+      int32_t in_data_count = 0;
+      parsec_static_op_t function_template_class_ptr[ttg::runtime_traits<ttg::Runtime::PaRSEC>::num_execution_spaces] = {nullptr};
       void *object_ptr = nullptr;
       void (*static_set_arg)(int, int) = nullptr;
       void (*deferred_release)(void*, parsec_ttg_op_base_t*) = nullptr; // callback used to release the task from with the static context of complete_task_and_release
       void *op_ptr = nullptr; // passed to deferred_release
 
+      inline
       parsec_ttg_op_base_t() {
-        PARSEC_OBJ_CONSTRUCT(&this->parsec_task, parsec_task_t);
+        //PARSEC_OBJ_CONSTRUCT(&this->parsec_task, parsec_task_t);
       }
     };
 
@@ -397,6 +398,7 @@ namespace ttg_parsec {
 
       typename ttg::meta::void_to_Void<Key>::type key;
 
+      inline
       parsec_ttg_op_t() : parsec_ttg_op_base_t()
       { }
     };


### PR DESCRIPTION
`my_op_t` is replaced by `parsec_ttg_op_t` and templated on the key type. `parsec_ttg_op_t` is derived from `parsec_ttg_op_base_t` which can be used in context where the key type is unknown or not needed. Storing the key inline avoids memory in the critical path taken when handling an input to a task that was not discovered yet.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>