### PR TITLE
Extend the examples/spmm example to work with larger matrices

### DIFF
--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -33,7 +33,7 @@ using namespace ttg;
 #if defined(BLOCK_SPARSE_GEMM) && defined(BTAS_IS_USABLE)
 using blk_t = btas::Tensor<double>;
 
-#if 1
+#if defined(TTG_USE_PARSEC)
 namespace ttg {
   template <>
   struct SplitMetadataDescriptor<blk_t> {
@@ -62,7 +62,7 @@ namespace ttg {
     }
   };
 }  // namespace ttg
-#endif
+#endif /* TTG_USE_PARSEC */
 
 // declare btas::Tensor serializable by Boost
 #include "ttg/serialization/backends/boost.h"

--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -706,11 +706,9 @@ int main(int argc, char **argv) {
       gettimeofday(&end, NULL);
       timersub(&end, &start, &diff);
       std::cout << "Time to completion: " << diff.tv_sec + (double)diff.tv_usec / 1e6 << "s" << std::endl;
-      ;
     } else {
       // ready, go! need only 1 kick, so must be done by 1 thread only
       if (ttg_default_execution_context().rank() == 0) control.start();
-      ttg_execute(ttg_default_execution_context());
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR replaces #103 

Add two options to examples/spmm:

- mm /path/to/a/MatrixMarket/sparse/matrix
- rmat N[:E[:a[:b[:c[:d]]]]] use a random graph generator in Boost to build the connectivity matrix of that graph

If either -mm or -rmat are used, we compute C = A * A, if A is
square, or C = A * A^T, if A is not square, where A
is the matrix provided / generated. Some rudimentary
statistics about the matrices (size and number of non zero),
and the time to compute the product.

If neither -mm or -rmat are specified, the example continues to
use the previous behavior.