### PR TITLE
Improvements to the PaRSEC backend

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -67,15 +67,15 @@ int parsec_add_fetch_runtime_task(parsec_taskpool_t *tp, int tasks);
 }
 
 namespace ttg_parsec {
-  static __thread parsec_task_t *parsec_ttg_caller;
-  static __thread parsec_execution_stream_t *parsec_ttg_es;
+  inline thread_local parsec_task_t *parsec_ttg_caller;
+  inline thread_local parsec_execution_stream_t *parsec_ttg_es;
 
   typedef void (*static_set_arg_fct_type)(void *, size_t, ttg::OpBase *);
   typedef std::pair<static_set_arg_fct_type, ttg::OpBase *> static_set_arg_fct_call_t;
-  static std::map<uint64_t, static_set_arg_fct_call_t> static_id_to_op_map;
-  static std::mutex static_map_mutex;
+  inline std::map<uint64_t, static_set_arg_fct_call_t> static_id_to_op_map;
+  inline std::mutex static_map_mutex;
   typedef std::tuple<int, void *, size_t> static_set_arg_fct_arg_t;
-  static std::multimap<uint64_t, static_set_arg_fct_arg_t> delayed_unpack_actions;
+  inline std::multimap<uint64_t, static_set_arg_fct_arg_t> delayed_unpack_actions;
 
   struct msg_header_t {
     typedef enum {

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1911,6 +1911,7 @@ namespace ttg_parsec {
         parsec_hash_table_lock_bucket(&tasks_table, hk);
         if (nullptr == (task = (task_t *)parsec_hash_table_nolock_find(&tasks_table, hk))) {
           task = create_new_task(key);
+          world_impl.increment_created();
         }
 
         // TODO: Unfriendly implementation, cannot check if stream is already bounded


### PR DESCRIPTION
- Template the task structure on the key type and the potential number of streaming terminals
- Use the local thread's execution stream, if available. Previously, all threads would hammer the same execution stream.
- Avoid locking hash tables where possible to reduce some congestion
- In a broadcast, submit tasks to `__parsec_schedule` at once 