### PR TITLE
recent LINALG++ kits expect mangling 

### DIFF
--- a/cmake/modules/FindOrFetchBTAS.cmake
+++ b/cmake/modules/FindOrFetchBTAS.cmake
@@ -7,7 +7,12 @@ endif (NOT TARGET BTAS::BTAS)
 
 if (NOT TARGET BTAS::BTAS)
 
-  set(BTAS_ENABLE_MKL ${ENABLE_MKL})
+  # BTAS will load BLAS++/LAPACK++ ... if those use CMake's FindBLAS/FindLAPACK (as indicated by defined BLA_VENDOR)
+  # will need to specify Fortran linkage convention ... manually for now, switching to NWX's linear algebra discovery
+  # is necessary to handle all the corner cases for automatic discovery
+  if (DEFINED BLA_VENDOR)
+    set(_linalgpp_use_standard_linalg_kits TRUE)
+  endif(DEFINED BLA_VENDOR)
 
   FetchContent_Declare(
       BTAS
@@ -27,6 +32,26 @@ if (NOT TARGET BTAS::BTAS)
 
   # set BTAS_CONFIG to the install location so that we know where to find it
   set(BTAS_CONFIG ${CMAKE_INSTALL_PREFIX}/${BTAS_INSTALL_CMAKEDIR}/btas-config.cmake)
+
+  # define macros specifying Fortran mangling convention, if necessary
+  if (_linalgpp_use_standard_linalg_kits)
+    if (NOT TARGET blaspp AND NOT TARGET lapackpp)
+      message(FATAL_ERROR "ouch")
+    endif(NOT TARGET blaspp AND NOT TARGET lapackpp)
+    if (TTG_LINALG_MANGLING STREQUAL lower)
+      target_compile_definitions(blaspp PUBLIC -DBLAS_FORTRAN_LOWER=1)
+      target_compile_definitions(lapackpp PUBLIC -DLAPACK_FORTRAN_LOWER=1)
+    elseif(TTG_LINALG_MANGLING STREQUAL UPPER OR TTG_LINALG_MANGLING STREQUAL upper)
+      target_compile_definitions(blaspp PUBLIC -DBLAS_FORTRAN_UPPER=1)
+      target_compile_definitions(lapackpp PUBLIC -DLAPACK_FORTRAN_UPPER=1)
+    else()
+      if (NOT TTG_LINALG_MANGLING STREQUAL lower_)
+        message(WARNING "Linear algebra libraries' mangling convention not specified; specify -DTTG_LINALG_MANGLING={lower,lower_,UPPER}, if needed; will assume lower_")
+      endif(NOT TTG_LINALG_MANGLING STREQUAL lower_)
+      target_compile_definitions(blaspp PUBLIC -DBLAS_FORTRAN_ADD_=1)
+      target_compile_definitions(lapackpp PUBLIC -DLAPACK_FORTRAN_ADD_=1)
+    endif()
+  endif (_linalgpp_use_standard_linalg_kits)
 
 endif(NOT TARGET BTAS::BTAS)
 


### PR DESCRIPTION
defined manually via macros BLAS_FORTRAN_{LOWER_UPPER_ADD_} and LAPACK_FORTRAN_{LOWER_UPPER_ADD_} if standard Find{BLAS,LAPACK} discovery kits are used
