### PR TITLE
Allow single keys (non-iterable) in ttg::broadcast

### DIFF
--- a/examples/potrf/potrf_pdc.cc
+++ b/examples/potrf/potrf_pdc.cc
@@ -288,7 +288,7 @@ auto make_potrf(MatrixT<T>& A,
       /* send tile to trsm */
       keylist.push_back(Key2(m, K));
     }
-    ttg::broadcast<0, 1>(std::make_tuple(std::array<Key2, 1>{Key2(K, K)}, keylist), std::move(tile_kk), out);
+    ttg::broadcast<0, 1>(std::make_tuple(Key2(K, K), keylist), std::move(tile_kk), out);
   };
   return ttg::make_tt(f, ttg::edges(input), ttg::edges(output_result, output_trsm), "POTRF", {"tile_kk"}, {"output_result", "output_trsm"});
 }
@@ -374,8 +374,8 @@ auto make_trsm(MatrixT<T>& A,
       keylist_col.push_back(Key3(m, I, K));
     }
 
-    ttg::broadcast<0, 1, 2, 3>(std::make_tuple(std::array<Key2, 1>{key},
-                                               std::array<Key2, 1>{Key2(I, K)},
+    ttg::broadcast<0, 1, 2, 3>(std::make_tuple(key,
+                                               Key2(I, K),
                                                keylist_row, keylist_col),
                             std::move(tile_mk), out);
   };

--- a/ttg/ttg/func.h
+++ b/ttg/ttg/func.h
@@ -154,7 +154,11 @@ namespace ttg {
   namespace detail {
     template <size_t KeyId, size_t i, size_t... I, typename ...RangesT, typename valueT, typename... output_terminalsT>
     void broadcast(const std::tuple<RangesT...>& keylists, valueT&& value, std::tuple<output_terminalsT...> &t) {
-      if (std::get<KeyId>(keylists).size() > 0) {
+      if constexpr (ttg::meta::is_iterable_v<std::tuple_element_t<KeyId, std::tuple<RangesT...>>>) {
+        if (std::distance(std::begin(std::get<KeyId>(keylists)), std::end(std::get<KeyId>(keylists))) > 0) {
+          std::get<i>(t).broadcast(std::get<KeyId>(keylists), value);
+        }
+      } else {
         std::get<i>(t).broadcast(std::get<KeyId>(keylists), value);
       }
       if constexpr(sizeof...(I) > 0) {

--- a/ttg/ttg/util/meta.h
+++ b/ttg/ttg/util/meta.h
@@ -387,6 +387,23 @@ template <typename Key, typename Value> using broadcast_callback_t = typename br
       using input_reducers_t = typename input_reducers<valueTs...>::type;
 
     }  // namespace detail
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // check whether a type is iterable
+    // Taken from https://en.cppreference.com/w/cpp/types/void_t
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    template <typename T, typename = void>
+    struct is_iterable : std::false_type {};
+
+    // this gets used only when we can call std::begin() and std::end() on that type
+    template <typename T>
+    struct is_iterable<T, std::void_t<decltype(std::begin(std::declval<T>())),
+                                      decltype(std::end(std::declval<T>()))
+                                    >
+                      > : std::true_type {};
+
+    template <typename T>
+    constexpr bool is_iterable_v = is_iterable<T>::value;
   } // namespace meta
 }  // namespace ttg
 


### PR DESCRIPTION
Makes using `1ttg::broadcast` slightly easier and cleaner. 

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>