### PR TITLE
Terminal: devirtualize the terminal type accessor

### DIFF
--- a/ttg/ttg/base/terminal.h
+++ b/ttg/ttg/base/terminal.h
@@ -23,9 +23,10 @@ namespace ttg {
 
   private:
     TTBase *tt;                  //< Pointer to containing operation
-    size_t n;                    //< Index of terminal
-    std::string name;            //< Name of terminal
-    bool connected;              //< True if is connected
+    size_t n = 0;                    //< Index of terminal
+    std::string name = "";            //< Name of terminal
+    bool connected = false;              //< True if is connected
+    Type type;
     std::string key_type_str;    //< String describing key type
     std::string value_type_str;  //< String describing value type
 
@@ -41,7 +42,7 @@ namespace ttg {
     friend class Out;
 
   protected:
-      TerminalBase() : tt(0), n(0), name(""), connected(false) {}
+    TerminalBase(Type type) : type(type) {}
 
     void set(TTBase *tt, size_t index, const std::string &name, const std::string &key_type_str,
             const std::string &value_type_str, Type type) {
@@ -50,6 +51,7 @@ namespace ttg {
       this->name = name;
       this->key_type_str = key_type_str;
       this->value_type_str = value_type_str;
+      this->type = type;
     }
 
     /// Add directed connection (this --> successor) in internal representation of the TTG.
@@ -88,7 +90,9 @@ namespace ttg {
     }
 
     /// Returns the terminal type
-    virtual Type get_type() const = 0;
+    Type get_type() {
+      return this->type;
+    }
 
     /// Get connections to successors
     const std::vector<TerminalBase *> &get_connections() const { return successors_; }

--- a/ttg/ttg/terminal.h
+++ b/ttg/ttg/terminal.h
@@ -50,7 +50,9 @@ namespace ttg {
     }
 
    public:
-    In() {}
+    In()
+    : TerminalBase(std::is_const<valueT>::value ? TerminalBase::Type::Read : TerminalBase::Type::Consume)
+    {}
 
     void set_callback(const send_callback_type &send_callback, const move_callback_type &move_callback,
                       const broadcast_callback_type &bcast_callback = broadcast_callback_type{},
@@ -167,10 +169,6 @@ namespace ttg {
       if (!finalize_callback) throw std::runtime_error("finalize callback not initialized");
       finalize_callback();
     }
-
-    Type get_type() const override {
-      return std::is_const<valueT>::value ? TerminalBase::Type::Read : TerminalBase::Type::Consume;
-    }
   };
 
   // Output terminal
@@ -194,7 +192,7 @@ namespace ttg {
     Out &operator=(const Out &&other) = delete;
 
    public:
-    Out() {}
+    Out() : TerminalBase(TerminalBase::Type::Write) {}
 
     /// \note will check data types unless macro \c NDEBUG is defined
     void connect(TerminalBase *in) override {
@@ -396,8 +394,6 @@ namespace ttg {
         }
       }
     }
-
-    Type get_type() const override { return TerminalBase::Type::Write; }
   };
 
 } // namespace ttg


### PR DESCRIPTION
The terminal type is a constant property of each terminal so it can be
delegated to the TerminalBase. No need for virtual methods...

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>