### PR TITLE
Avoid div in the default keymap if there is only one process

### DIFF
--- a/ttg/ttg/base/keymap.h
+++ b/ttg/ttg/base/keymap.h
@@ -21,7 +21,13 @@ namespace ttg {
 
       template <typename Key = keyT>
       std::enable_if_t<!meta::is_void_v<Key>,int>
-      operator()(const Key &key) const { return ttg::hash<keyT>{}(key) % world_size; }
+      operator()(const Key &key) const {
+        if (world_size == 1) {
+          return 0;
+        } else {
+          return ttg::hash<keyT>{}(key) % world_size;
+        }
+      }
       template <typename Key = keyT>
       std::enable_if_t<meta::is_void_v<Key>,int>
       operator()() const { return 0; }


### PR DESCRIPTION
Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>