### PR TITLE
Devirtualize WorldImpl::size and rank

### DIFF
--- a/ttg/ttg/base/world.h
+++ b/ttg/ttg/base/world.h
@@ -42,6 +42,8 @@ namespace ttg {
       std::vector<std::function<void()>> m_callbacks;
       std::vector<std::shared_ptr<void>> m_ptrs;
       std::vector<std::unique_ptr<void, std::function<void(void*)>>> m_unique_ptrs;
+      int world_size;
+      int world_rank;
       bool m_is_valid = true;
 
      protected:
@@ -55,14 +57,21 @@ namespace ttg {
         }
       }
 
-     public:
-      WorldImplBase(void) {}
+    protected:
+      WorldImplBase(int size, int rank)
+      : world_size(size), world_rank(rank)
+      {}
 
+    public:
       virtual ~WorldImplBase(void) { m_is_valid = false; }
 
-      virtual int size(void) const = 0;
+      int size(void) {
+        return world_size;
+      }
 
-      virtual int rank(void) const = 0;
+      int rank(void) {
+        return world_rank;
+      }
 
       virtual void destroy(void) = 0;
 

--- a/ttg/ttg/base/world.h
+++ b/ttg/ttg/base/world.h
@@ -65,11 +65,17 @@ namespace ttg {
     public:
       virtual ~WorldImplBase(void) { m_is_valid = false; }
 
-      int size(void) {
+      /**
+       * Returns the number of processes that belong this World.
+       */
+      int size() {
         return world_size;
       }
 
-      int rank(void) {
+      /**
+       * Returns the rank of the calling process in this World.
+       */
+      int rank() {
         return world_rank;
       }
 
@@ -94,6 +100,12 @@ namespace ttg {
         m_callbacks.emplace_back(callback);
       }
 
+
+      /**
+       * Wait for all tasks in this world to complete execution.
+       * This is a synchronizing call, even if no active tasks exist
+       * (i.e., fence() behaves as a barrier).
+       */
       void fence(void) {
         fence_impl();
         for (auto& status : m_statuses) {
@@ -106,18 +118,39 @@ namespace ttg {
         m_callbacks.clear();  // clear out the statuses
       }
 
+      /**
+       * Start the execution of tasks in this world. The call to execute()
+       * will return immediately, i.e., it will not wait for all tasks
+       * to complete executing.
+       *
+       * \sa fence
+       */
       virtual void execute() {}
 
+
+      /**
+       * Register a TT with this world. All registered TTs will be
+       * destroyed during destruction of this world.
+       */
       void register_op(ttg::TTBase* op) {
         // TODO: do we need locking here?
         m_op_register.push_back(op);
       }
 
+      /**
+       * Deregister a TT from this world. TTs deregister themselves during
+       * destruction to avoid dangling references.
+       */
       void deregister_op(ttg::TTBase* op) {
         // TODO: do we need locking here?
         m_op_register.remove(op);
       }
 
+
+      /**
+       * Whether this world is valid. A word is marked as invalid during destruction
+       * and/or finalization of TTG.
+       */
       bool is_valid(void) const { return m_is_valid; }
 
       virtual void final_task() {}

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -69,9 +69,14 @@ namespace ttg_madness {
     ttg::Edge<> m_ctl_edge;
 
    public:
-    WorldImpl(::madness::World &world) : m_impl(world) {}
+    WorldImpl(::madness::World &world)
+    : WorldImplBase(world.size(), world.rank())
+    , m_impl(world)
+    {}
 
-    WorldImpl(const SafeMPI::Intracomm &comm) : m_impl(*new ::madness::World(comm)), m_allocated(true) {}
+    WorldImpl(const SafeMPI::Intracomm &comm)
+    : WorldImplBase(comm.Get_size(), comm.Get_rank())
+    , m_impl(*new ::madness::World(comm)), m_allocated(true) {}
 
     /* Deleted copy ctor */
     WorldImpl(const WorldImpl &other) = delete;
@@ -86,10 +91,6 @@ namespace ttg_madness {
 
     /* Deleted move assignment */
     WorldImpl &operator=(WorldImpl &&other) = delete;
-
-    virtual int size(void) const override { return m_impl.size(); }
-
-    virtual int rank(void) const override { return m_impl.rank(); }
 
     virtual void fence_impl(void) override { m_impl.gop.fence(); }
 

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -194,9 +194,24 @@ namespace ttg_parsec {
 
     ttg::Edge<> m_ctl_edge;
 
+    int query_comm_size() {
+      int comm_size;
+      MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+      return comm_size;
+    }
+
+    int query_comm_rank() {
+      int comm_rank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
+      return comm_rank;
+    }
+
+
    public:
     static constexpr const int PARSEC_TTG_MAX_AM_SIZE = 1024 * 1024;
-    WorldImpl(int *argc, char **argv[], int ncores) {
+    WorldImpl(int *argc, char **argv[], int ncores)
+    : WorldImplBase(query_comm_size(), query_comm_rank())
+    {
       ttg::detail::register_world(*this);
       ctx = parsec_init(ncores, argc, argv);
       es = ctx->virtual_processes[0]->execution_streams[0];
@@ -254,19 +269,6 @@ namespace ttg_parsec {
 
     constexpr int parsec_ttg_tag() const { return _PARSEC_TTG_TAG; }
     constexpr int parsec_ttg_rma_tag() const { return _PARSEC_TTG_RMA_TAG; }
-
-    virtual int size() const override {
-      int size;
-
-      MPI_Comm_size(comm(), &size);
-      return size;
-    }
-
-    virtual int rank() const override {
-      int rank;
-      MPI_Comm_rank(comm(), &rank);
-      return rank;
-    }
 
     MPI_Comm comm() const { return MPI_COMM_WORLD; }
 


### PR DESCRIPTION
Also avoid MPI calls in the PaRSEC backend (I was sure I had fixed that somewhere...)

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>