### PR TITLE
[WIP] UxT-Reducer streaming terminals

### DIFF
--- a/examples/floyd-warshall/floyd_warshall.cc
+++ b/examples/floyd-warshall/floyd_warshall.cc
@@ -95,8 +95,7 @@ std::ostream& operator<<(std::ostream& s, const Control& ctl) {
 
 class Initiator : public TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
                             Initiator> {
-  using baseT =
-      TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, Initiator>;
+  using baseT = typename Initiator::ttT;
 
  public:
   Initiator(const std::string& name) : baseT(name, {}, {"outA", "outB", "outC", "outD"}) {}
@@ -128,11 +127,8 @@ class Initiator : public TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>
 class FuncA : public TT<Key,
                         std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>,
                                    Out<Key, Control>, Out<Key, Control>>,
-                        FuncA, Control> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>,
-                              Out<Key, Control>, Out<Key, Control>>,
-                   FuncA, Control>;
+                        FuncA, std::tuple<Control>> {
+  using baseT = typename FuncA::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -224,10 +220,8 @@ class FuncB
     : public TT<
           Key,
           std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-          FuncB, Control, Control> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-         FuncB, Control, Control>;
+          FuncB, std::tuple<Control, Control>> {
+  using baseT = typename FuncB::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -317,10 +311,8 @@ class FuncC
     : public TT<
           Key,
           std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-          FuncC, Control, Control> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-         FuncC, Control, Control>;
+          FuncC, std::tuple<Control, Control>> {
+  using baseT = typename FuncC::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -407,9 +399,8 @@ class FuncC
 };
 
 class FuncD : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-                        FuncD, Control, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncD,
-                   Control, Control, Control>;
+                        FuncD, std::tuple<Control, Control, Control>> {
+  using baseT = typename FuncD::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/floyd-warshall/floyd_warshall_df.cc
+++ b/examples/floyd-warshall/floyd_warshall_df.cc
@@ -154,8 +154,8 @@ class Initiator : public TT<int,
 };
 
 template <typename T>
-class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>> {
-  using baseT = TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>>;
+class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, std::tuple<BlockMatrix<T>>> {
+  using baseT = typename Finalizer::ttT;
   Matrix<T>* result_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -236,12 +236,8 @@ class FuncA : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncA<T>, BlockMatrix<T>> {
-  using baseT = TT<
-      Key,
-      std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                 Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-      FuncA, BlockMatrix<T>>;
+                        FuncA<T>, std::tuple<BlockMatrix<T>>> {
+  using baseT = typename FuncA::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -339,11 +335,8 @@ template <typename T>
 class FuncB : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncB<T>, BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncB, BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncB<T>, std::tuple<BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncB::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -432,11 +425,8 @@ template <typename T>
 class FuncC : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncC<T>, BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncC, BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncC<T>, std::tuple<BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncC::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -524,11 +514,8 @@ template <typename T>
 class FuncD : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncD<T>, BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncD, BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncD<T>, std::tuple<BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncD::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/ge/ge.cc
+++ b/examples/ge/ge.cc
@@ -130,8 +130,7 @@ std::ostream& operator<<(std::ostream& s, const Integer& intVal) {
 class Initiator
     : public TT<Integer, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
                 Initiator> {
-  using baseT =
-      TT<Integer, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, Initiator>;
+  using baseT = typename Initiator::ttT;
 
  public:
   Initiator(const std::string& name) : baseT(name, {}, {"outA", "outB", "outC", "outD"}) {}
@@ -160,8 +159,8 @@ class Initiator
   }
 };
 
-class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, Control>;
+class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, std::tuple<Control>> {
+  using baseT = typename FuncA::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -240,8 +239,8 @@ class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Ou
   }
 };
 
-class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Control>;
+class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, std::tuple<Control, Control>> {
+  using baseT = typename FuncB::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -312,8 +311,8 @@ class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Cont
   }
 };
 
-class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Control>;
+class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, std::tuple<Control, Control>> {
+  using baseT = typename FuncC::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -385,9 +384,8 @@ class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Cont
 };
 
 class FuncD : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-                        FuncD, Control, Control, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncD,
-                   Control, Control, Control, Control>;
+                        FuncD, std::tuple<Control, Control, Control, Control>> {
+  using baseT = typename FuncD::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/ge/ge_df.cc
+++ b/examples/ge/ge_df.cc
@@ -136,10 +136,7 @@ class Initiator : public TT<Integer,
                             std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                        Out<Key, BlockMatrix<T>>>,
                             Initiator<T>> {
-  using baseT = TT<Integer,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   Initiator>;
+  using baseT = typename Initiator::ttT;
 
   Matrix<T>* adjacency_matrix_ttg;
 
@@ -179,8 +176,8 @@ class Initiator : public TT<Integer,
 };
 
 template <typename T>
-class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>> {
-  using baseT = TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>>;
+class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, std::tuple<BlockMatrix<T>>> {
+  using baseT = typename Finalizer::ttT;
   Matrix<T>* result_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -256,11 +253,8 @@ template <typename T>
 class FuncA : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncA<T>, BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   FuncA, BlockMatrix<T>>;
+                        FuncA<T>, std::tuple<BlockMatrix<T>>> {
+  using baseT = typename FuncA::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -346,10 +340,9 @@ class FuncA : public TT<Key,
 };
 
 template <typename T>
-class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncB<T>, BlockMatrix<T>,
-                        BlockMatrix<T>> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncB, BlockMatrix<T>, BlockMatrix<T>>;
+class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncB<T>,
+                        std::tuple<BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncB::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -427,10 +420,9 @@ class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, Block
 };
 
 template <typename T>
-class FuncC : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncC<T>, BlockMatrix<T>,
-                        BlockMatrix<T>> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncC, BlockMatrix<T>, BlockMatrix<T>>;
+class FuncC : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncC<T>,
+                        std::tuple<BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncC::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -512,11 +504,8 @@ template <typename T>
 class FuncD : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncD<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   FuncD, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>>;
+                        FuncD<T>, std::tuple<BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncD::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/madness/madness-1d/madness-1d.cc
+++ b/examples/madness/madness-1d/madness-1d.cc
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <utility>
 
-#include "ttg/madness/ttg.h"
+#include "ttg.h"
 
 #include "Vector.h"
 #include "Matrix.h"
@@ -309,8 +309,8 @@ std::ostream& operator<<(std::ostream&s, const Control& ctl) {
     return s;
 }
 
-class Printer : public TT<Key, std::tuple<>, Printer, Node> {
-    using baseT = TT<Key, std::tuple<>, Printer, Node>;
+class Printer : public TT<Key, std::tuple<>, Printer, std::tuple<Node>> {
+    using baseT = typename Printer::ttT;
 public:
     Printer(const std::string& name) : baseT(name, {"input"}, {}) {}
 
@@ -325,8 +325,8 @@ public:
 };
 
 
-class GaxpyOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, Node, Node> {
-	using baseT =  TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, Node, Node>;
+class GaxpyOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, std::tuple<Node, Node>> {
+	using baseT =  typename GaxpyOp::ttT;
 
 	double alpha;
 	double beta;
@@ -369,8 +369,8 @@ public:
 };
 
 
-class BinaryOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, BinaryOp, Node, Node> {
-	using baseT =   TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, BinaryOp, Node, Node>;
+class BinaryOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, BinaryOp, std::tuple<Node, Node>> {
+	using baseT =   typename BinaryOp::ttT;
 
    using funcT = Vector (*)(const Vector &, const Vector&);
    funcT func;
@@ -430,8 +430,8 @@ public:
 };
 
 
-class Diff_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_prologue, Node> {
-   using baseT =  	     TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_prologue, Node>;
+class Diff_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_prologue, std::tuple<Node>> {
+   using baseT = typename Diff_prologue::ttT;
 
 public:
 
@@ -452,8 +452,8 @@ public:
    }
 };
 
-class Diff_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_doIt, Node, Node, Node> {
-   using baseT =         TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_doIt, Node, Node, Node>;
+class Diff_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_doIt, std::tuple<Node, Node, Node>> {
+   using baseT = typename Diff_doIt::ttT;
 
    Vector unfilter(const Vector &inputVector, int k, const Matrix * hg) const {
       Vector inputVector_copy(inputVector);
@@ -530,8 +530,8 @@ public:
 };
 
 
-class Compress_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_prologue, Node> {
-   using baseT = 		 TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_prologue, Node>;
+class Compress_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_prologue, std::tuple<Node>> {
+   using baseT = typename Compress_prologue::ttT;
 
 public:
    Compress_prologue(const std::string &name)
@@ -564,8 +564,8 @@ public:
 
 };
 
-class Compress_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_doIt, Node, Node> {
-   using baseT = 	     TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_doIt, Node, Node>;
+class Compress_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_doIt, std::tuple<Node, Node>> {
+   using baseT = typename Compress_doIt::ttT;
 
 public:
    Compress_doIt(const std::string &name)
@@ -607,8 +607,8 @@ public:
 };
 
 
-class Reconstruct_prologue : public TT<Key, std::tuple<Out<Key, Vector>>, Reconstruct_prologue, Node> {
-   using baseT = 		    TT<Key, std::tuple<Out<Key, Vector>>, Reconstruct_prologue, Node>;
+class Reconstruct_prologue : public TT<Key, std::tuple<Out<Key, Vector>>, Reconstruct_prologue, std::tuple<Node>> {
+   using baseT = typename Reconstruct_prologue::ttT;
 
 public:
    Reconstruct_prologue(const std::string &name)
@@ -633,8 +633,8 @@ public:
 };
 
 
-class Reconstruct_doIt : public TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>, Reconstruct_doIt, Vector, Node> {
-   using baseT = TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>, Reconstruct_doIt, Vector, Node>;
+class Reconstruct_doIt : public TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>, Reconstruct_doIt, std::tuple<Vector, Node>> {
+   using baseT = typename Reconstruct_doIt::ttT;
 
 public:
    Reconstruct_doIt(const std::string &name)
@@ -672,8 +672,8 @@ public:
 };
 
 
-class Project : public  TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>, Project, Control> {
-    using baseT = 	TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>, Project, Control>;
+class Project : public  TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>, Project, std::tuple<Control>> {
+    using baseT = typename Project::ttT;
 
  public:
     using funcT = double(*)(double);
@@ -733,7 +733,7 @@ private:
 };
 
 class Producer : public TT<Key, std::tuple<Out<Key, Control>>, Producer> {
-	using baseT = 		TT<Key, std::tuple<Out<Key, Control>>, Producer>;
+	using baseT = typename Producer::ttT;
 
 public:
 	Producer(const std::string &name) : baseT(name, {}, {"output"}) {}
@@ -753,7 +753,7 @@ public:
 
 // EXAMPLE 1
 class Everything : public TT<Key, std::tuple<>, Everything> {
-  using baseT = TT<Key, std::tuple<>, Everything>;
+  using baseT = Everything::ttT;
 
   Producer producer;
   Project project;

--- a/examples/madness/mrattg_streaming.cc
+++ b/examples/madness/mrattg_streaming.cc
@@ -366,7 +366,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,cnodeOut<T,K,1>>;
         using compress_in_type  = std::tuple<Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<1>, compress_out_type, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<1>, compress_out_type, std::tuple<Rin, Rin>>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,2>{
@@ -375,7 +375,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,cnodeOut<T,K,2>>;
         using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<2>, compress_out_type, Rin, Rin, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<2>, compress_out_type, std::tuple<Rin, Rin, Rin, Rin>>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,3>{
@@ -384,7 +384,7 @@ namespace detail {
       using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,Rout,Rout,Rout,Rout,cnodeOut<T,K,3>>;
       using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<3>, compress_out_type, Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<3>, compress_out_type, std::tuple<Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>>;
     };
 };
 

--- a/examples/mrafunctionnode.h
+++ b/examples/mrafunctionnode.h
@@ -174,10 +174,6 @@ namespace mra {
         FunctionReconstructedNode(const Key<NDIM>& key) : key(key), sum(0.0), is_leaf(false) {}
         T normf() const {return (is_leaf ? coeffs.normf() : 0.0);}
         bool has_children() const {return !is_leaf;}
-    	//Can't make it a vector to keep the class as POD.
-        std::array<FixedTensor<T, K, NDIM>, 1 << NDIM> neighbor_coeffs;
-        std::array<bool, 1 << NDIM> is_neighbor_leaf;
-        std::array<T, 1 << NDIM> neighbor_sum;
     };
     
     template <typename T, size_t K, Dimension NDIM>

--- a/examples/randomaccess/randomaccess.cc
+++ b/examples/randomaccess/randomaccess.cc
@@ -12,6 +12,7 @@
 #define CHUNKBIG (32*CHUNK)
 
 #include "ttg.h"
+#include "ttg/serialization.h"
 using namespace ttg;
 
 typedef struct params {

--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -188,9 +188,9 @@ inline int tile2rank(int i, int j, int P, int Q) {
 
 // flow data from an existing SpMatrix on rank 0
 template <typename Blk = blk_t, typename Keymap = std::function<int(const Key<2> &)>>
-class Read_SpMatrix : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read_SpMatrix<Blk>, void> {
+class Read_SpMatrix : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read_SpMatrix<Blk>, std::tuple<void>> {
  public:
-  using baseT = TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read_SpMatrix<Blk>, void>;
+  using baseT = typename Read_SpMatrix::ttT;
 
   Read_SpMatrix(const char *label, const SpMatrix<Blk> &matrix, Edge<Key<2>> &ctl, Edge<Key<2>, Blk> &out,
                 Keymap &keymap)
@@ -214,9 +214,9 @@ class Read_SpMatrix : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read_SpMat
 
 // flow (move?) data into an existing SpMatrix on rank 0
 template <typename Blk = blk_t>
-class Write_SpMatrix : public TT<Key<2>, std::tuple<>, Write_SpMatrix<Blk>, Blk> {
+class Write_SpMatrix : public TT<Key<2>, std::tuple<>, Write_SpMatrix<Blk>, std::tuple<Blk>> {
  public:
-  using baseT = TT<Key<2>, std::tuple<>, Write_SpMatrix<Blk>, Blk>;
+  using baseT = typename Write_SpMatrix::ttT;
 
   template <typename Keymap>
   Write_SpMatrix(SpMatrix<Blk> &matrix, Edge<Key<2>, Blk> &in, Keymap &&keymap)
@@ -286,9 +286,9 @@ class SpMM {
   }
 
   /// Locally broadcast A[i][k] to all {i,j,k} such that B[j][k] exists
-  class LocalBcastA : public TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastA, Blk> {
+  class LocalBcastA : public TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastA, std::tuple<const Blk>> {
    public:
-    using baseT = TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastA, Blk>;
+    using baseT = typename LocalBcastA::ttT;
 
     LocalBcastA(Edge<Key<3>, Blk> &a, Edge<Key<3>, Blk> &a_ijk,
                 const std::vector<std::vector<long>> &b_rowidx_to_colidx, Keymap keymap)
@@ -321,9 +321,9 @@ class SpMM {
   };  // class LocalBcastA
 
   /// broadcast A[i][k] to all procs where B[j][k]
-  class BcastA : public TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastA, Blk> {
+  class BcastA : public TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastA, std::tuple<const Blk>> {
    public:
-    using baseT = TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastA, Blk>;
+    using baseT = typename BcastA::ttT;
 
     BcastA(Edge<Key<2>, Blk> &a, Edge<Key<3>, Blk> &a_ikp, const std::vector<std::vector<long>> &b_rowidx_to_colidx,
            Keymap keymap)
@@ -356,9 +356,9 @@ class SpMM {
   };  // class BcastA
 
   /// broadcast B[k][j] to all {i,j,k} such that A[i][k] exists
-  class LocalBcastB : public TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastB, Blk> {
+  class LocalBcastB : public TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastB, std::tuple<const Blk>> {
    public:
-    using baseT = TT<Key<3>, std::tuple<Out<Key<3>, Blk>>, LocalBcastB, Blk>;
+    using baseT = typename LocalBcastB::ttT;
 
     LocalBcastB(Edge<Key<3>, Blk> &b, Edge<Key<3>, Blk> &b_ijk,
                 const std::vector<std::vector<long>> &a_colidx_to_rowidx, Keymap keymap)
@@ -391,9 +391,9 @@ class SpMM {
   };  // class BcastA
 
   /// broadcast B[k][j] to all {i,j,k} such that A[i][k] exists
-  class BcastB : public TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastB, Blk> {
+  class BcastB : public TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastB, std::tuple<const Blk>> {
    public:
-    using baseT = TT<Key<2>, std::tuple<Out<Key<3>, Blk>>, BcastB, Blk>;
+    using baseT = typename BcastB::ttT;
 
     BcastB(Edge<Key<2>, Blk> &b, Edge<Key<3>, Blk> &b_kjp, const std::vector<std::vector<long>> &a_colidx_to_rowidx,
            Keymap keymap)
@@ -426,9 +426,9 @@ class SpMM {
 
   /// multiply task has 3 input flows: a_ijk, b_ijk, and c_ijk, c_ijk contains the running total
   class MultiplyAdd
-      : public TT<Key<3>, std::tuple<Out<Key<2>, Blk>, Out<Key<3>, Blk>>, MultiplyAdd, const Blk, const Blk, Blk> {
+      : public TT<Key<3>, std::tuple<Out<Key<2>, Blk>, Out<Key<3>, Blk>>, MultiplyAdd, std::tuple<const Blk, const Blk, Blk>> {
    public:
-    using baseT = TT<Key<3>, std::tuple<Out<Key<2>, Blk>, Out<Key<3>, Blk>>, MultiplyAdd, const Blk, const Blk, Blk>;
+    using baseT = typename MultiplyAdd::ttT;
 
     MultiplyAdd(Edge<Key<3>, Blk> &a_ijk, Edge<Key<3>, Blk> &b_ijk, Edge<Key<3>, Blk> &c_ijk, Edge<Key<2>, Blk> &c,
                 const std::vector<std::vector<long>> &a_rowidx_to_colidx,
@@ -604,7 +604,7 @@ class SpMM {
 };
 
 class Control : public TT<void, std::tuple<Out<Key<2>>>, Control> {
-  using baseT = TT<void, std::tuple<Out<Key<2>>>, Control>;
+  using baseT = typename Control::ttT;
   int P;
   int Q;
 

--- a/examples/t9/t9.cc
+++ b/examples/t9/t9.cc
@@ -280,8 +280,8 @@ auto make_reconstruct(const nodeEdge& in, nodeEdge& out, const std::string& name
 }
 
 // cannot easily replace this with make_tt due to persistent state
-class Norm2 : public TT<Key, std::tuple<>, Norm2, Node> {
-  using baseT = TT<Key, std::tuple<>, Norm2, Node>;
+class Norm2 : public TT<Key, std::tuple<>, Norm2, std::tuple<Node>> {
+  using baseT = typename Norm2::ttT;
   double sumsq;
   std::mutex charon;
 

--- a/examples/t9/t9_streaming.cc
+++ b/examples/t9/t9_streaming.cc
@@ -293,7 +293,7 @@ auto make_reconstruct(const nodeEdge& in, nodeEdge& out, const std::string& name
 
 // cannot easily replace this with wrapper due to persistent state
 class Norm2 : public TT<Key, std::tuple<>, Norm2, std::tuple<Node>> {
-  using baseT = TT<Key, std::tuple<>, Norm2, std::tuple<Node>>;
+  using baseT = typename Norm2::ttT;
   double sumsq;
   std::mutex charon;
 

--- a/examples/t9/t9_streaming.cc
+++ b/examples/t9/t9_streaming.cc
@@ -292,8 +292,8 @@ auto make_reconstruct(const nodeEdge& in, nodeEdge& out, const std::string& name
 }
 
 // cannot easily replace this with wrapper due to persistent state
-class Norm2 : public TT<Key, std::tuple<>, Norm2, Node> {
-  using baseT = TT<Key, std::tuple<>, Norm2, Node>;
+class Norm2 : public TT<Key, std::tuple<>, Norm2, std::tuple<Node>> {
+  using baseT = TT<Key, std::tuple<>, Norm2, std::tuple<Node>>;
   double sumsq;
   std::mutex charon;
 

--- a/examples/test/test.cc
+++ b/examples/test/test.cc
@@ -16,7 +16,7 @@ using keyT = uint64_t;
 #include "ttg.h"
 
 class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, std::tuple<const int>> {
-  using baseT = TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, std::tuple<const int>>;
+  using baseT = typename A::ttT;
 
  public:
   A(const std::string &name) : baseT(name, {"inputA"}, {"resultA", "iterateA"}) {}
@@ -53,7 +53,7 @@ class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, std::tu
 };
 
 class Producer : public TT<void, std::tuple<Out<keyT, int>>, Producer> {
-  using baseT = TT<void, std::tuple<Out<keyT, int>>, Producer>;
+  using baseT = typename Producer::ttT;
 
  public:
   Producer(const std::string &name) : baseT(name, {}, {"output"}) {}
@@ -70,7 +70,7 @@ class Producer : public TT<void, std::tuple<Out<keyT, int>>, Producer> {
 };
 
 class Consumer : public TT<void, std::tuple<>, Consumer, std::tuple<const int>> {
-  using baseT = TT<void, std::tuple<>, Consumer, std::tuple<const int>>;
+  using baseT = typename Consumer::ttT;
 
  public:
   Consumer(const std::string &name) : baseT(name, {"input"}, {}) {}

--- a/examples/test/test.cc
+++ b/examples/test/test.cc
@@ -12,8 +12,8 @@ using keyT = uint64_t;
 
 #include "ttg.h"
 
-class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, const int> {
-  using baseT = TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, const int>;
+class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, std::tuple<const int>> {
+  using baseT = TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, std::tuple<const int>>;
 
  public:
   A(const std::string &name) : baseT(name, {"inputA"}, {"resultA", "iterateA"}) {}
@@ -66,8 +66,8 @@ class Producer : public TT<void, std::tuple<Out<keyT, int>>, Producer> {
   ~Producer() { std::cout << " Producer destructor\n"; }
 };
 
-class Consumer : public TT<void, std::tuple<>, Consumer, const int> {
-  using baseT = TT<void, std::tuple<>, Consumer, const int>;
+class Consumer : public TT<void, std::tuple<>, Consumer, std::tuple<const int>> {
+  using baseT = TT<void, std::tuple<>, Consumer, std::tuple<const int>>;
 
  public:
   Consumer(const std::string &name) : baseT(name, {"input"}, {}) {}

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -7,8 +7,8 @@
 // {task_id,data} = {void, void}
 namespace tt_v_v {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, void> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, void>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -26,8 +26,8 @@ namespace tt_v_v {
 // {task_id,data} = {int, void}
 namespace tt_i_v {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, void> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, void>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -45,8 +45,8 @@ namespace tt_i_v {
 // {task_id,data} = {void, int}
 namespace tt_v_i {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, const int> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, const int>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -65,8 +65,8 @@ namespace tt_v_i {
 // {task_id,data} = {void, int, void}
 namespace tt_v_iv {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, const int, void> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, const int, void>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int, void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -85,8 +85,8 @@ namespace tt_v_iv {
 // {task_id,data} = {int, int}
 namespace tt_i_i {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, const int> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, const int>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int>> {
+    using baseT = typename tt:ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -104,8 +104,8 @@ namespace tt_i_i {
 // {task_id,data} = {int, int, void}
 namespace tt_i_iv {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, const int, void> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, const int, void>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int, void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,

--- a/ttg/ttg/broadcast.h
+++ b/ttg/ttg/broadcast.h
@@ -26,10 +26,10 @@ namespace ttg {
   ///
   template <typename Value, typename OutKey = int>
   class BinaryTreeBroadcast : public TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                                        BinaryTreeBroadcast<Value, OutKey>, Value> {
+                                        BinaryTreeBroadcast<Value, OutKey>, std::tuple<Value>> {
    public:
     using baseT = TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                     BinaryTreeBroadcast<Value, OutKey>, Value>;
+                     BinaryTreeBroadcast<Value, OutKey>, std::tuple<Value>>;
 
     BinaryTreeBroadcast(Edge<int, Value> &in, Edge<OutKey, Value> &out, std::vector<OutKey> local_keys, int root = 0,
                         World world = ttg::default_execution_context(), int max_key = -1,

--- a/ttg/ttg/edge.h
+++ b/ttg/ttg/edge.h
@@ -138,6 +138,19 @@ namespace ttg {
     typedef std::tuple<typename edgesT::output_terminal_type...> type;
   };
 
+  template<typename keyT, typename... valuesT>
+  struct edges_tuple {
+    using type = std::tuple<ttg::Edge<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  struct edges_tuple<keyT, std::tuple<valuesT...>> {
+    using type = std::tuple<ttg::Edge<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  using edges_tuple_t = typename edges_tuple<keyT, valuesT...>::type;
+
 
 } // namespace ttg
 

--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -7,7 +7,8 @@
 
 namespace ttg_madness {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT,
+            typename input_terminal_typesT = std::tuple<>, typename input_argsT = input_terminal_typesT>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -205,7 +205,10 @@ namespace ttg_madness {
    public:
     using input_terminals_type = ttg::input_terminals_tuple_t<keyT, input_terminal_typesT>;
     using input_args_type = input_argsT;
-    using full_args_type = ttg::meta::decayed_tuple_t<input_args_type>;
+    using full_args_type =
+        typename ttg::meta::decayed_tuple_t<
+          std::conditional_t<ttg::meta::is_none_void_v<input_args_type>, input_args_type,
+                             typename ttg::meta::drop_last_n<input_args_type, std::size_t{1}>::type>>;
     using input_edges_type = ttg::edges_tuple_t<keyT, ttg::meta::decayed_tuple_t<input_terminal_typesT>>;
     static_assert(ttg::meta::is_none_Void_v<input_terminal_typesT>, "ttg::Void is for internal use only, do not use it");
     static_assert(ttg::meta::is_none_Void_v<input_argsT>,       "ttg::Void is for internal use only, do not use it");
@@ -487,7 +490,6 @@ namespace ttg_madness {
 
       using input_arg_type = std::decay_t<std::tuple_element_t<i, input_args_type>>;
       using decay_value_t = std::decay_t<valueT>;
-      constexpr const bool edge_arg_same_type = std::is_same_v<decay_value_t, input_arg_type>;
       constexpr const bool edge_arg_convertible = std::is_convertible_v<decay_value_t, input_arg_type>;
 
       const int owner = keymap();

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -7,7 +7,8 @@
 
 namespace ttg_parsec {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT,
+            typename input_edge_typesT = std::tuple<>, typename input_argsT = input_edge_typesT>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -2472,8 +2472,9 @@ namespace ttg_parsec {
         return;
       }
       alive = false;
-      /* print all outstanding tasks */
-      parsec_hash_table_for_all(&tasks_table, ht_iter_cb, this);
+      /* Not sure why but both GCC-10 and Clang-14 fail if 'this' is passed directly */
+      void *cb_data = this;
+      parsec_hash_table_for_all(&tasks_table, ht_iter_cb, cb_data);
       parsec_hash_table_fini(&tasks_table);
       parsec_mempool_destruct(&mempools);
       // uintptr_t addr = (uintptr_t)self.incarnations;

--- a/ttg/ttg/reduce.h
+++ b/ttg/ttg/reduce.h
@@ -28,10 +28,10 @@ namespace ttg {
   template <typename Value, typename BinaryOp, typename OutKey>
   class BinaryTreeReduce
       : public TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                  BinaryTreeReduce<Value, BinaryOp, OutKey>, Value, Value, Value> {
+                  BinaryTreeReduce<Value, BinaryOp, OutKey>, std::tuple<Value, Value, Value>> {
    public:
     using baseT = TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                     BinaryTreeReduce<Value, BinaryOp, OutKey>, Value, Value, Value>;
+                     BinaryTreeReduce<Value, BinaryOp, OutKey>, std::tuple<Value, Value, Value>>;
 
     BinaryTreeReduce(Edge<int, Value> &in, Edge<OutKey, Value> &out, int root = 0, OutKey dest_key = OutKey(),
                      BinaryOp op = BinaryOp{}, World world = ttg::default_execution_context(), int max_key = -1,

--- a/ttg/ttg/terminal.h
+++ b/ttg/ttg/terminal.h
@@ -178,6 +178,20 @@ namespace ttg {
     }
   };
 
+  template<typename keyT, typename... valuesT>
+  struct input_terminals_tuple {
+    using type = std::tuple<ttg::In<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  struct input_terminals_tuple<keyT, std::tuple<valuesT...>> {
+    using type = std::tuple<ttg::In<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  using input_terminals_tuple_t = typename input_terminals_tuple<keyT, valuesT...>::type;
+
+
   // Output terminal
   template <typename keyT = void, typename valueT = void>
   class Out : public TerminalBase {
@@ -381,6 +395,20 @@ namespace ttg {
       }
     }
   };
+
+  template<typename keyT, typename... valuesT>
+  struct output_terminals_tuple {
+    using type = std::tuple<ttg::Out<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  struct output_terminals_tuple<keyT, std::tuple<valuesT...>> {
+    using type = std::tuple<ttg::Out<keyT, valuesT>...>;
+  };
+
+  template<typename keyT, typename... valuesT>
+  using output_terminals_tuple_t = typename output_terminals_tuple<keyT, valuesT...>::type;
+
 
 } // namespace ttg
 

--- a/ttg/ttg/util/env.cpp
+++ b/ttg/ttg/util/env.cpp
@@ -5,6 +5,7 @@
 #include "ttg/util/env.h"
 
 #include <thread>
+#include <stdexcept>
 
 #include <cstdlib>
 

--- a/ttg/ttg/util/meta.h
+++ b/ttg/ttg/util/meta.h
@@ -239,6 +239,49 @@ namespace ttg {
     template <typename tupleT>
     using add_lvalue_reference_tuple_t = typename add_lvalue_reference_tuple<tupleT>::type;
 
+    template<typename T, typename... Ts>
+    struct none_has_reference
+    {
+      static constexpr bool value = !std::is_reference_v<T> && none_has_reference<Ts...>::value;
+    };
+
+    template<typename T>
+    struct none_has_reference<T>
+    {
+      static constexpr bool value = !std::is_reference_v<T>;
+    };
+
+    template<typename T>
+    struct tuple_none_has_reference;
+
+    template<typename T, typename... Ts>
+    struct tuple_none_has_reference<std::tuple<T, Ts...>>
+    {
+      static constexpr bool value = none_has_reference<T, Ts...>::value;
+    };
+
+    template<>
+    struct tuple_none_has_reference<std::tuple<>>
+    {
+      static constexpr bool value = true;
+    };
+
+
+    template<typename... Ts>
+    constexpr bool tuple_none_has_reference_v = tuple_none_has_reference<Ts...>::value;
+
+    template<typename T>
+    struct is_tuple : std::integral_constant<bool, false>
+    { };
+
+    template<typename... Ts>
+    struct is_tuple<std::tuple<Ts...>> : std::integral_constant<bool, true>
+    { };
+
+    template<typename T>
+    constexpr bool is_tuple_v = is_tuple<T>::value;
+
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // is_empty_tuple
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ttg/ttg/util/meta.h
+++ b/ttg/ttg/util/meta.h
@@ -67,7 +67,7 @@ namespace ttg {
     };
 
     // tuple<Ts...> -> tuple<std::remove_reference_t<Ts>...>
-    template <typename T, typename Enabler = void>
+    template <typename T>
     struct nonref_tuple;
 
     template <typename... Ts>
@@ -79,7 +79,7 @@ namespace ttg {
     using nonref_tuple_t = typename nonref_tuple<Tuple>::type;
 
     // tuple<Ts...> -> tuple<std::decay_t<Ts>...>
-    template <typename T, typename Enabler = void>
+    template <typename T>
     struct decayed_tuple;
 
     template <typename... Ts>
@@ -89,6 +89,33 @@ namespace ttg {
 
     template <typename Tuple>
     using decayed_tuple_t = typename decayed_tuple<Tuple>::type;
+
+
+    // like std::add_const but adds const to references
+    template<typename T>
+    struct add_const {
+      using type = std::add_const_t<T>;
+    };
+
+    template<typename T>
+    struct add_const<T&> {
+      using type = std::add_lvalue_reference_t<std::add_const_t<T>>;
+    };
+
+    template<typename T>
+    using add_const_t = typename add_const<T>::type;
+
+    // tuple<Ts...> -> tuple<std::add_const<Ts>...>
+    template <typename T>
+    struct add_const_tuple;
+
+    template <typename... Ts>
+    struct add_const_tuple<std::tuple<Ts...>> {
+      using type = std::tuple<typename add_const<Ts>::type...>;
+    };
+
+    template <typename Tuple>
+    using add_const_tuple_t = typename add_const_tuple<Tuple>::type;
 
     template <typename Tuple1, typename Tuple2>
     struct tuple_concat;


### PR DESCRIPTION
Implement UxT reduction streaming terminals. The types of edge inputs and the types of the `op` arguments (if different) are passed as tuples instead of variadic template arguments. This allows us to convert between U and T and to use different U and T for the reducer signature. 

This is WIP and so far only contains a draft of the interface in the PaRSEC backend, no UxT reducer tests yet. 

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>