### PR TITLE
[WIP] Dynamic TT attributes

### DIFF
--- a/ttg/CMakeLists.txt
+++ b/ttg/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ttg-base-headers
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/base/world.h
     )
 set(ttg-impl-headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/ttg/attributes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/broadcast.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/edge.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/execution.h

--- a/ttg/ttg/attributes.h
+++ b/ttg/ttg/attributes.h
@@ -1,0 +1,147 @@
+#ifndef TTG_ATTRIBUTES_H
+#define TTG_ATTRIBUTES_H
+
+namespace ttg {
+
+
+    /**
+     * A set of attributes supported by TTG.
+     */
+    enum class Attribute : size_t {
+      PRIORITY = 0,
+      PROCESS,
+      FINAL,
+      SOURCE,
+      IMMEDIATE
+    };
+
+
+    /**
+     * An attribute value that can store either a fixed value or a function
+     * to query that value based on a provided key.
+     */
+    template<Attribute A, typename KeyT, typename ValueT>
+    struct AttributeValue {
+      using value_type = std::decay_t<ValueT>;
+      using key_type   = std::decay_t<KeyT>;
+      using function_type = std::function<value_type(const key_type&)>;
+      static constexpr const Attribute attribute_id = A;
+    private:
+      function_type fn;
+      value_type val;
+    public:
+
+      AttributeValue() : val(value_type{})
+      { }
+
+      template<typename Value_>
+      AttributeValue(Value_&& value) : val(std::forward<Value_>(value))
+      { }
+
+      template<typename Fn, typename = std::enable_if_t<std::is_invocable_r_v<ValueT, Fn, KeyT>>>
+      void set(Fn&& fn) {
+        this->fn = std::forward<Fn>(fn);
+      }
+
+      void set(value_type val) {
+        this->val = val;
+        this->fn = nullptr;
+      }
+
+      value_type get(const KeyT& key) const {
+        return fn ? fn(key) : val;
+      }
+
+      value_type operator()(const KeyT& key) const {
+        return get(key);
+      }
+
+    };
+
+
+    /* Overload for keys of type void */
+    template<Attribute A, typename ValueT>
+    struct AttributeValue<A, void, ValueT> {
+      using value_type = std::decay_t<ValueT>;
+      using function_type = std::function<value_type(void)>;
+      static constexpr const Attribute attribute_id = A;
+    private:
+      function_type fn;
+      value_type val;
+    public:
+
+      AttributeValue() : val(value_type{})
+      { }
+
+      template<typename Value_>
+      AttributeValue(Value_&& value) : val(std::forward<Value_>(value))
+      { }
+
+      template<typename Fn, typename = std::enable_if_t<std::is_invocable_v<Fn>>>
+      void set(Fn&& fn) {
+        this->fn = std::forward<Fn>(fn);
+      }
+
+      void set(value_type val) {
+        this->val = val;
+        this->fn = nullptr;
+      }
+
+      value_type get(void) const {
+        return fn ? fn() : val;
+      }
+
+      value_type operator()() const {
+        return get();
+      }
+
+    };
+
+    /* Overload for keys of type ttg::Void */
+    template<Attribute A, typename ValueT>
+    struct AttributeValue<A, ttg::Void, ValueT> {
+      using value_type = std::decay_t<ValueT>;
+      using function_type = std::function<value_type(void)>;
+      static constexpr const Attribute attribute_id = A;
+    private:
+      function_type fn;
+      value_type val;
+    public:
+
+      AttributeValue() : val(value_type{})
+      { }
+
+      template<typename Value_>
+      AttributeValue(Value_&& value) : val(std::forward<Value_>(value))
+      { }
+
+      template<typename Fn, typename = std::enable_if_t<std::is_invocable_v<Fn>>>
+      void set(Fn&& fn) {
+        this->fn = std::forward<Fn>(fn);
+      }
+
+      void set(value_type val) {
+        this->val = val;
+        this->fn = nullptr;
+      }
+
+      value_type get(void) const {
+        return fn ? fn() : val;
+      }
+
+      value_type operator()() const {
+        return get();
+      }
+
+    };
+
+    template<typename KeyT>
+    using tt_attribute_set_t = std::tuple<AttributeValue<Attribute::PRIORITY,  KeyT, int32_t>,
+                                          AttributeValue<Attribute::PROCESS,   KeyT, int32_t>,
+                                          AttributeValue<Attribute::FINAL,     KeyT, bool>,
+                                          AttributeValue<Attribute::SOURCE,    KeyT, bool>,
+                                          AttributeValue<Attribute::IMMEDIATE, KeyT, bool>>;
+
+} // namespace ttg
+
+#endif // TTG_ATTRIBUTES_H


### PR DESCRIPTION
Implement a generic interface for attributes in TTs. An attribute may store either a value of specified type or a function mapping a task id to a value. Attributes may be set dynamically, i.e., the value and function can be changed at runtime. Setting a value or function overrides any previously set value or function.

Attributes availabe so far:

- Process mapping (deprecates `set_keymap`)
- Priority (deprecates `set_priomap`)
- Final * (the task won't spawn any new tasks; not sure how useful this is)
- Source * (the task has no predecessors; not sure how useful this is)
- Immediate * (the task may be executed immediately; useful for operation with short runtimes)

(*) not yet implemented

We may want to add an attribute to denote pure tasks once we support them.

Attributes are set using 

```C
tt->set_attribute<ttg::Attribute::<ATTRIBUTE>>(<priority-value>)
```
or 

```C
tt->set_attribute<ttg::Attribute::<ATTRIBUTE>>([](const TaskId& id){ return <priority-value-of-id>; })
```

These attributes are currently defined for TTs. Should they be specific to an `op`, i.e., do we want different attributes for `op` and `op_cuda`? 

Do we want attributes on a per-terminal basis? Which ones?