### PR TITLE
Make sure get_trace() always returns a value

### DIFF
--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -150,15 +150,12 @@ namespace ttg {
 
     /// @return false if `trace_enabled()==false`, else true if tracing set for either this instance or all instances
     bool get_trace() {
-      if constexpr (trace_enabled()) return ttg::detail::tt_base_trace_accessor() || trace_instance;
+      return trace_enabled() && (ttg::detail::tt_base_trace_accessor() || trace_instance);
     }
 
     /// @return false if `trace_enabled()==false`, else true if tracing set for either this instance or all instances
     bool tracing() {
-      if constexpr (trace_enabled())
-        return get_trace();
-      else
-        return false;
+      return get_trace();
     }
 
     /// Like ttg::trace(), but only produces tracing output if `this->tracing()==true`

--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -149,13 +149,11 @@ namespace ttg {
     }
 
     /// @return false if `trace_enabled()==false`, else true if tracing set for either this instance or all instances
-    bool get_trace() {
-      return trace_enabled() && (ttg::detail::tt_base_trace_accessor() || trace_instance);
-    }
-
-    /// @return false if `trace_enabled()==false`, else true if tracing set for either this instance or all instances
-    bool tracing() {
-      return get_trace();
+    bool tracing() const {
+      if constexpr (trace_enabled())
+        return ttg::detail::tt_base_trace_accessor() || trace_instance;
+      else
+        return false;
     }
 
     /// Like ttg::trace(), but only produces tracing output if `this->tracing()==true`

--- a/ttg/ttg/util/trace.h
+++ b/ttg/ttg/util/trace.h
@@ -25,7 +25,12 @@ namespace ttg {
   /// To enable tracing invoke trace_on(). To disable tracing
   /// \return false, if `trace_enabled()==false`, otherwise returns true if the most recent call to `trace_on()`
   /// has not been followed by `trace_off()`
-  inline bool tracing() { return trace_enabled() ? detail::trace_accessor() : false; }
+  inline bool tracing() {
+    if constexpr (trace_enabled())
+      return detail::trace_accessor();
+    else
+      return false;
+  }
 
   /// \brief enables tracing; if `trace_enabled()==true` this has no effect
   inline void trace_on() { if constexpr (trace_enabled()) detail::trace_accessor() = true; }


### PR DESCRIPTION
Also, tracing() is just an alias for get_trace()

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>