### PR TITLE
Simplify loops in ttg::Out::send

### DIFF
--- a/ttg/ttg/base/terminal.h
+++ b/ttg/ttg/base/terminal.h
@@ -90,7 +90,7 @@ namespace ttg {
     }
 
     /// Returns the terminal type
-    Type get_type() {
+    Type get_type() const {
       return this->type;
     }
 


### PR DESCRIPTION
No need to loop over the successors twice.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>