### PR TITLE
Implement Policies

### DIFF
--- a/examples/floyd-warshall/floyd_warshall.cc
+++ b/examples/floyd-warshall/floyd_warshall.cc
@@ -95,8 +95,7 @@ std::ostream& operator<<(std::ostream& s, const Control& ctl) {
 
 class Initiator : public TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
                             Initiator> {
-  using baseT =
-      TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, Initiator>;
+  using baseT = typename Initiator::ttT;
 
  public:
   Initiator(const std::string& name) : baseT(name, {}, {"outA", "outB", "outC", "outD"}) {}
@@ -128,11 +127,8 @@ class Initiator : public TT<int, std::tuple<Out<Key, Control>, Out<Key, Control>
 class FuncA : public TT<Key,
                         std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>,
                                    Out<Key, Control>, Out<Key, Control>>,
-                        FuncA, Control> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>,
-                              Out<Key, Control>, Out<Key, Control>>,
-                   FuncA, Control>;
+                        FuncA, ttg::typelist<Control>> {
+  using baseT = typename FuncA::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -224,10 +220,8 @@ class FuncB
     : public TT<
           Key,
           std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-          FuncB, Control, Control> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-         FuncB, Control, Control>;
+          FuncB, ttg::typelist<Control, Control>> {
+  using baseT = typename FuncB::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -317,10 +311,8 @@ class FuncC
     : public TT<
           Key,
           std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-          FuncC, Control, Control> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-         FuncC, Control, Control>;
+          FuncC, ttg::typelist<Control, Control>> {
+  using baseT = typename FuncC::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -407,9 +399,8 @@ class FuncC
 };
 
 class FuncD : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-                        FuncD, Control, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncD,
-                   Control, Control, Control>;
+                        FuncD, ttg::typelist<Control, Control, Control>> {
+  using baseT = typename FuncD::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/floyd-warshall/floyd_warshall_df.cc
+++ b/examples/floyd-warshall/floyd_warshall_df.cc
@@ -14,8 +14,8 @@
 #include <utility>
 
 #if __has_include(<execution>)
-#include <execution>
-#define HAS_EXECUTION_HEADER
+//#include <execution>
+//#define HAS_EXECUTION_HEADER
 #endif
 
 #include "ttg.h"
@@ -109,10 +109,7 @@ class Initiator : public TT<int,
                             std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                        Out<Key, BlockMatrix<T>>>,
                             Initiator<T>> {
-  using baseT = TT<int,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   Initiator>;
+  using baseT = typename Initiator::ttT;
   Matrix<T>* adjacency_matrix_ttg;
 
  public:
@@ -154,8 +151,8 @@ class Initiator : public TT<int,
 };
 
 template <typename T>
-class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>> {
-  using baseT = TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>>;
+class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, ttg::typelist<BlockMatrix<T>>> {
+  using baseT = typename Finalizer::ttT;
   Matrix<T>* result_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -236,12 +233,8 @@ class FuncA : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncA<T>, BlockMatrix<T>> {
-  using baseT = TT<
-      Key,
-      std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                 Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-      FuncA, BlockMatrix<T>>;
+                        FuncA<T>, ttg::typelist<BlockMatrix<T>>> {
+  using baseT = typename FuncA::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -339,11 +332,8 @@ template <typename T>
 class FuncB : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncB<T>, BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncB, BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncB<T>, ttg::typelist<BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncB::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -432,11 +422,8 @@ template <typename T>
 class FuncC : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncC<T>, BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncC, BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncC<T>, ttg::typelist<BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncC::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -524,11 +511,8 @@ template <typename T>
 class FuncD : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                        FuncD<T>, BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
-                   FuncD, BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>>;
+                        FuncD<T>, ttg::typelist<BlockMatrix<T>, const BlockMatrix<T>, const BlockMatrix<T>>> {
+  using baseT = typename FuncD::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/ge/ge.cc
+++ b/examples/ge/ge.cc
@@ -130,8 +130,7 @@ std::ostream& operator<<(std::ostream& s, const Integer& intVal) {
 class Initiator
     : public TT<Integer, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
                 Initiator> {
-  using baseT =
-      TT<Integer, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, Initiator>;
+  using baseT = typename Initiator::ttT;
 
  public:
   Initiator(const std::string& name) : baseT(name, {}, {"outA", "outB", "outC", "outD"}) {}
@@ -160,8 +159,8 @@ class Initiator
   }
 };
 
-class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, Control>;
+class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncA, ttg::typelist<Control>> {
+  using baseT = typename FuncA::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -240,8 +239,8 @@ class FuncA : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Ou
   }
 };
 
-class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Control>;
+class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, ttg::typelist<Control, Control>> {
+  using baseT = typename FuncB::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -312,8 +311,8 @@ class FuncB : public TT<Key, std::tuple<Out<Key, Control>>, FuncB, Control, Cont
   }
 };
 
-class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Control>;
+class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, ttg::typelist<Control, Control>> {
+  using baseT = typename FuncC::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -385,9 +384,8 @@ class FuncC : public TT<Key, std::tuple<Out<Key, Control>>, FuncC, Control, Cont
 };
 
 class FuncD : public TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>,
-                        FuncD, Control, Control, Control, Control> {
-  using baseT = TT<Key, std::tuple<Out<Key, Control>, Out<Key, Control>, Out<Key, Control>, Out<Key, Control>>, FuncD,
-                   Control, Control, Control, Control>;
+                        FuncD, ttg::typelist<Control, Control, Control, Control>> {
+  using baseT = typename FuncD::ttT;
   double* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/ge/ge_df.cc
+++ b/examples/ge/ge_df.cc
@@ -136,10 +136,7 @@ class Initiator : public TT<Integer,
                             std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                        Out<Key, BlockMatrix<T>>>,
                             Initiator<T>> {
-  using baseT = TT<Integer,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   Initiator>;
+  using baseT = typename Initiator::ttT;
 
   Matrix<T>* adjacency_matrix_ttg;
 
@@ -179,8 +176,8 @@ class Initiator : public TT<Integer,
 };
 
 template <typename T>
-class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>> {
-  using baseT = TT<Key, std::tuple<>, Finalizer<T>, BlockMatrix<T>>;
+class Finalizer : public TT<Key, std::tuple<>, Finalizer<T>, ttg::typelist<BlockMatrix<T>>> {
+  using baseT = typename Finalizer::ttT;
   Matrix<T>* result_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -256,11 +253,8 @@ template <typename T>
 class FuncA : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncA<T>, BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   FuncA, BlockMatrix<T>>;
+                        FuncA<T>, ttg::typelist<BlockMatrix<T>>> {
+  using baseT = typename FuncA::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -346,10 +340,9 @@ class FuncA : public TT<Key,
 };
 
 template <typename T>
-class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncB<T>, BlockMatrix<T>,
-                        BlockMatrix<T>> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncB, BlockMatrix<T>, BlockMatrix<T>>;
+class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
+                        FuncB<T>, ttg::typelist<BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncB::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -427,10 +420,9 @@ class FuncB : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, Block
 };
 
 template <typename T>
-class FuncC : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncC<T>, BlockMatrix<T>,
-                        BlockMatrix<T>> {
-  using baseT =
-      TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>, FuncC, BlockMatrix<T>, BlockMatrix<T>>;
+class FuncC : public TT<Key, std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>>,
+                        FuncC<T>, ttg::typelist<BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncC::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;
@@ -512,11 +504,8 @@ template <typename T>
 class FuncD : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
-                        FuncD<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>> {
-  using baseT = TT<Key,
-                   std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
-                              Out<Key, BlockMatrix<T>>>,
-                   FuncD, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>>;
+                        FuncD<T>, ttg::typelist<BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>>> {
+  using baseT = typename FuncD::ttT
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/ge/ge_df.cc
+++ b/examples/ge/ge_df.cc
@@ -505,7 +505,7 @@ class FuncD : public TT<Key,
                         std::tuple<Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>, Out<Key, BlockMatrix<T>>,
                                    Out<Key, BlockMatrix<T>>>,
                         FuncD<T>, ttg::typelist<BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>, BlockMatrix<T>>> {
-  using baseT = typename FuncD::ttT
+  using baseT = typename FuncD::ttT;
   Matrix<T>* adjacency_matrix_ttg;
   int problem_size;
   int blocking_factor;

--- a/examples/madness/madness-1d/madness-1d.cc
+++ b/examples/madness/madness-1d/madness-1d.cc
@@ -309,8 +309,8 @@ std::ostream& operator<<(std::ostream&s, const Control& ctl) {
     return s;
 }
 
-class Printer : public TT<Key, std::tuple<>, Printer, Node> {
-    using baseT = TT<Key, std::tuple<>, Printer, Node>;
+class Printer : public TT<Key, std::tuple<>, Printer, ttg::typelist<Node>> {
+    using baseT = typename Printer::ttT;
 public:
     Printer(const std::string& name) : baseT(name, {"input"}, {}) {}
 
@@ -325,8 +325,8 @@ public:
 };
 
 
-class GaxpyOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, Node, Node> {
-	using baseT =  TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, Node, Node>;
+class GaxpyOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, GaxpyOp, ttg::typelist<Node, Node>> {
+	using baseT =  typename GaxpyOp::ttT;
 
 	double alpha;
 	double beta;
@@ -369,8 +369,9 @@ public:
 };
 
 
-class BinaryOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, BinaryOp, Node, Node> {
-	using baseT =   TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, BinaryOp, Node, Node>;
+class BinaryOp : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>,
+                           BinaryOp, ttg::typelist<Node, Node>> {
+	using baseT = typename BinaryOp::ttT;
 
    using funcT = Vector (*)(const Vector &, const Vector&);
    funcT func;
@@ -430,8 +431,9 @@ public:
 };
 
 
-class Diff_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_prologue, Node> {
-   using baseT =  	     TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_prologue, Node>;
+class Diff_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>,
+                                Diff_prologue, ttg::typelist<Node>> {
+   using baseT = typename Diff_prologue::ttT;
 
 public:
 
@@ -452,8 +454,9 @@ public:
    }
 };
 
-class Diff_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_doIt, Node, Node, Node> {
-   using baseT =         TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Diff_doIt, Node, Node, Node>;
+class Diff_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>,
+                            Diff_doIt, ttg::typelist<Node, Node, Node>> {
+   using baseT = typename Diff_doIt::ttT;
 
    Vector unfilter(const Vector &inputVector, int k, const Matrix * hg) const {
       Vector inputVector_copy(inputVector);
@@ -530,8 +533,9 @@ public:
 };
 
 
-class Compress_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_prologue, Node> {
-   using baseT = 		 TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_prologue, Node>;
+class Compress_prologue : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>,
+                                    Compress_prologue, ttg::typelist<Node>> {
+   using baseT = typename Compress_prologue::ttT;
 
 public:
    Compress_prologue(const std::string &name)
@@ -564,8 +568,9 @@ public:
 
 };
 
-class Compress_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_doIt, Node, Node> {
-   using baseT = 	     TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>, Compress_doIt, Node, Node>;
+class Compress_doIt : public TT<Key, std::tuple<Out<Key, Node>, Out<Key, Node>, Out<Key, Node>>,
+                                Compress_doIt, ttg::typelist<Node, Node>> {
+   using baseT = typename Compress_doIt::ttT;
 
 public:
    Compress_doIt(const std::string &name)
@@ -607,8 +612,9 @@ public:
 };
 
 
-class Reconstruct_prologue : public TT<Key, std::tuple<Out<Key, Vector>>, Reconstruct_prologue, Node> {
-   using baseT = 		    TT<Key, std::tuple<Out<Key, Vector>>, Reconstruct_prologue, Node>;
+class Reconstruct_prologue : public TT<Key, std::tuple<Out<Key, Vector>>,
+                                       Reconstruct_prologue, ttg::typelist<Node>> {
+   using baseT = typename Reconstruct_prologue::ttT;
 
 public:
    Reconstruct_prologue(const std::string &name)
@@ -633,8 +639,9 @@ public:
 };
 
 
-class Reconstruct_doIt : public TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>, Reconstruct_doIt, Vector, Node> {
-   using baseT = TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>, Reconstruct_doIt, Vector, Node>;
+class Reconstruct_doIt : public TT<Key, std::tuple<Out<Key, Vector>, Out<Key, Node>>,
+                                   Reconstruct_doIt, ttg::typelist<Vector, Node>> {
+   using baseT = typename Reconstruct_doIt::ttT;
 
 public:
    Reconstruct_doIt(const std::string &name)
@@ -672,8 +679,9 @@ public:
 };
 
 
-class Project : public  TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>, Project, Control> {
-    using baseT = 	TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>, Project, Control>;
+class Project : public  TT<Key, std::tuple<Out<Key,Control>, Out<Key,Node>>,
+                           Project, ttg::typelist<Control>> {
+    using baseT = typename Project::ttT;
 
  public:
     using funcT = double(*)(double);
@@ -733,7 +741,7 @@ private:
 };
 
 class Producer : public TT<Key, std::tuple<Out<Key, Control>>, Producer> {
-	using baseT = 		TT<Key, std::tuple<Out<Key, Control>>, Producer>;
+	using baseT = typename Producer::ttT;
 
 public:
 	Producer(const std::string &name) : baseT(name, {}, {"output"}) {}
@@ -753,7 +761,7 @@ public:
 
 // EXAMPLE 1
 class Everything : public TT<Key, std::tuple<>, Everything> {
-  using baseT = TT<Key, std::tuple<>, Everything>;
+  using baseT = typename Everything::ttT;
 
   Producer producer;
   Project project;

--- a/examples/madness/mrattg.cc
+++ b/examples/madness/mrattg.cc
@@ -135,7 +135,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,cnodeOut<T,K,1>>;
         using compress_in_type  = std::tuple<Rin, Rin>;
         template <typename compfuncT>
-        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<1>, compress_out_type, Rin, Rin>;
+        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<1>, compress_out_type, ttg::TTPolicyBase<Key<1>>, Rin, Rin>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,2>{
@@ -144,7 +144,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,cnodeOut<T,K,2>>;
         using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<2>, compress_out_type, Rin, Rin, Rin, Rin>;
+        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<2>, compress_out_type, ttg::TTPolicyBase<Key<2>>, Rin, Rin, Rin, Rin>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,3>{
@@ -153,7 +153,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,Rout,Rout,Rout,Rout,cnodeOut<T,K,3>>;
         using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<3>, compress_out_type, Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
+        using compwrap_type = ttg::CallableWrapTT<compfuncT, Key<3>, compress_out_type, ttg::TTPolicyBase<Key<3>>, Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
     };
 };
 
@@ -237,7 +237,8 @@ auto make_compress(rnodeEdge<T,K,NDIM>& in, cnodeEdge<T,K,NDIM>& out, const std:
     constexpr size_t num_children = Key<NDIM>::num_children;
 
     using sendfuncT = decltype(&send_leaves_up<T,K,NDIM>);
-    using sendwrapT = ttg::CallableWrapTT<sendfuncT, Key<NDIM>, typename ::detail::tree_types<T,K,NDIM>::compress_out_type, FunctionReconstructedNode<T,K,NDIM> >;
+    using sendwrapT = ttg::CallableWrapTT<sendfuncT, Key<NDIM>, typename ::detail::tree_types<T,K,NDIM>::compress_out_type,
+                                          ttg::TTPolicyBase<Key<NDIM>>, FunctionReconstructedNode<T,K,NDIM> >;
     using compfuncT = decltype(&do_compress<T,K,NDIM>);
     using compwrapT = typename ::detail::tree_types<T,K,NDIM>::template compwrap_type<compfuncT>;
 

--- a/examples/madness/mrattg_streaming.cc
+++ b/examples/madness/mrattg_streaming.cc
@@ -366,7 +366,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,cnodeOut<T,K,1>>;
         using compress_in_type  = std::tuple<Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<1>, compress_out_type, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<1>, compress_out_type, ttg::typelist<Rin, Rin>>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,2>{
@@ -375,7 +375,7 @@ namespace detail {
         using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,cnodeOut<T,K,2>>;
         using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<2>, compress_out_type, Rin, Rin, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<2>, compress_out_type, ttg::typelist<Rin, Rin, Rin, Rin>>;
     };
 
     template <typename T, size_t K>  struct tree_types<T,K,3>{
@@ -384,7 +384,7 @@ namespace detail {
       using compress_out_type = std::tuple<Rout,Rout,Rout,Rout,Rout,Rout,Rout,Rout,cnodeOut<T,K,3>>;
       using compress_in_type  = std::tuple<Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
         template <typename compfuncT>
-        using compmake_tt_type = ttg::TT<compfuncT, Key<3>, compress_out_type, Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>;
+        using compmake_tt_type = ttg::TT<compfuncT, Key<3>, compress_out_type, ttg::typelist<Rin, Rin, Rin, Rin, Rin, Rin, Rin, Rin>>;
     };
 };
 

--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -202,7 +202,7 @@ class Read_SpMatrix : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read_SpMat
     auto rank = ttg::default_execution_context().rank();
     for (int k = 0; k < matrix_.outerSize(); ++k) {
       for (typename SpMatrix<Blk>::InnerIterator it(matrix_, k); it; ++it) {
-        if (rank == this->get_policy().procmap(Key<2>({it.row(), it.col()})))
+        if (rank == this->procmap(Key<2>({it.row(), it.col()})))
           ::send<0>(Key<2>({it.row(), it.col()}), it.value(), out);
       }
     }
@@ -339,9 +339,8 @@ class SpMM {
       if (k >= b_rowidx_to_colidx_.size()) return;
       auto world = default_execution_context();
       std::vector<bool> procmap(world.size());
-      auto& policy = baseT::get_policy();
       for (auto &j : b_rowidx_to_colidx_[k]) {
-        long proc = policy.procmap(Key<2>({i, j}));
+        long proc = this->procmap(Key<2>({i, j}));
         if (!procmap[proc]) {
           ttg::trace("Broadcasting A[", i, "][", k, "] to proc ", proc);
           ikp_keys.emplace_back(Key<3>({i, k, proc}));
@@ -410,7 +409,7 @@ class SpMM {
       auto world = default_execution_context();
       std::vector<bool> procmap(world.size());
       for (auto &i : a_colidx_to_rowidx_[k]) {
-        long proc = baseT::get_policy().procmap(Key<2>({i, j}));
+        long proc = this->procmap(Key<2>({i, j}));
         if (!procmap[proc]) {
           ttg::trace("Broadcasting A[", k, "][", j, "] to proc ", proc);
           kjp_keys.emplace_back(Key<3>({k, j, proc}));

--- a/examples/t9/t9.cc
+++ b/examples/t9/t9.cc
@@ -280,8 +280,8 @@ auto make_reconstruct(const nodeEdge& in, nodeEdge& out, const std::string& name
 }
 
 // cannot easily replace this with make_tt due to persistent state
-class Norm2 : public TT<Key, std::tuple<>, Norm2, Node> {
-  using baseT = TT<Key, std::tuple<>, Norm2, Node>;
+class Norm2 : public TT<Key, std::tuple<>, Norm2, ttg::typelist<Node>> {
+  using baseT = typename Norm2::ttT;
   double sumsq;
   std::mutex charon;
 

--- a/examples/t9/t9_streaming.cc
+++ b/examples/t9/t9_streaming.cc
@@ -292,8 +292,8 @@ auto make_reconstruct(const nodeEdge& in, nodeEdge& out, const std::string& name
 }
 
 // cannot easily replace this with wrapper due to persistent state
-class Norm2 : public TT<Key, std::tuple<>, Norm2, Node> {
-  using baseT = TT<Key, std::tuple<>, Norm2, Node>;
+class Norm2 : public TT<Key, std::tuple<>, Norm2, ttg::typelist<Node>> {
+  using baseT = typename Norm2::ttT;
   double sumsq;
   std::mutex charon;
 

--- a/examples/test/test.cc
+++ b/examples/test/test.cc
@@ -12,8 +12,8 @@ using keyT = uint64_t;
 
 #include "ttg.h"
 
-class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, const int> {
-  using baseT = TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, const int>;
+class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, ttg::typelist<const int>> {
+  using baseT = typename A::ttT;
 
  public:
   A(const std::string &name) : baseT(name, {"inputA"}, {"resultA", "iterateA"}) {}
@@ -50,7 +50,7 @@ class A : public TT<keyT, std::tuple<Out<void, int>, Out<keyT, int>>, A, const i
 };
 
 class Producer : public TT<void, std::tuple<Out<keyT, int>>, Producer> {
-  using baseT = TT<void, std::tuple<Out<keyT, int>>, Producer>;
+  using baseT = typename Producer::ttT;
 
  public:
   Producer(const std::string &name) : baseT(name, {}, {"output"}) {}
@@ -66,8 +66,8 @@ class Producer : public TT<void, std::tuple<Out<keyT, int>>, Producer> {
   ~Producer() { std::cout << " Producer destructor\n"; }
 };
 
-class Consumer : public TT<void, std::tuple<>, Consumer, const int> {
-  using baseT = TT<void, std::tuple<>, Consumer, const int>;
+class Consumer : public TT<void, std::tuple<>, Consumer, ttg::typelist<const int>> {
+  using baseT = typename Consumer::ttT;
 
  public:
   Consumer(const std::string &name) : baseT(name, {"input"}, {}) {}

--- a/examples/ttg_matrix.h
+++ b/examples/ttg_matrix.h
@@ -193,9 +193,9 @@ namespace ttg {
 
     // compute shape of an existing SpMatrix on rank 0
     template <typename Blk = blk_t>
-    class ReadShape : public TT<void, std::tuple<Out<void, Shape>>, ReadShape<Blk>, void> {
+    class ReadShape : public TT<void, std::tuple<Out<void, Shape>>, ReadShape<Blk>, ttg::typelist<void>> {
      public:
-      using baseT = TT<void, std::tuple<Out<void, Shape>>, ReadShape<Blk>, void>;
+      using baseT = typename ReadShape::ttT;
       static constexpr const int owner = 0;  // where data resides
 
       ReadShape(const char *label, const SpMatrix<Blk> &matrix, Edge<void, void> &in, Edge<void, Shape> &out)
@@ -218,7 +218,7 @@ namespace ttg {
     // - this could be generalized to read efficiently from a distributed data structure
     // Use Read_SpMatrix if need to read all data from a data structure localized on 1 process
     template <typename Blk = blk_t>
-    class Read : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read<Blk>, void> {
+    class Read : public TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read<Blk>, ttg::typelist<void>> {
      public:
       using baseT = TT<Key<2>, std::tuple<Out<Key<2>, Blk>>, Read<Blk>, void>;
       static constexpr const int owner = 0;  // where data resides
@@ -243,9 +243,9 @@ namespace ttg {
     // since SpMatrix supports random inserts there is no need to commit the shape into the matrix, other than get the
     // dimensions
     template <typename Blk = blk_t>
-    class WriteShape : public TT<void, std::tuple<Out<void, Shape>>, WriteShape<Blk>, Shape> {
+    class WriteShape : public TT<void, std::tuple<Out<void, Shape>>, WriteShape<Blk>, ttg::typelist<Shape>> {
      public:
-      using baseT = TT<void, std::tuple<Out<void, Shape>>, WriteShape<Blk>, Shape>;
+      using baseT = typename WriteShape::ttT;
       static constexpr const int owner = 0;  // where data resides
 
       WriteShape(const char *label, SpMatrix<Blk> &matrix, Edge<void, Shape> &in, Edge<void, Shape> &out)
@@ -267,9 +267,9 @@ namespace ttg {
 
     // flow (move?) data into an existing SpMatrix on rank 0
     template <typename Blk = blk_t>
-    class Write : public TT<Key<2>, std::tuple<>, Write<Blk>, Blk, void> {
+    class Write : public TT<Key<2>, std::tuple<>, Write<Blk>, Blk, ttg::typelist<void>> {
      public:
-      using baseT = TT<Key<2>, std::tuple<>, Write<Blk>, Blk, void>;
+      using baseT = typename Write::ttT;
 
       Write(const char *label, SpMatrix<Blk> &matrix, Edge<Key<2>, Blk> &data_in, Edge<Key<2>, void> &ctl_in)
           : baseT(edges(data_in, ctl_in), edges(), std::string("write_spmatrix(") + label + ")",
@@ -315,9 +315,9 @@ namespace ttg {
     };
 
     // ShapeAdd adds two Shape objects
-    class ShapeAdd : public TT<void, std::tuple<Out<void, Shape>>, ShapeAdd, Shape, Shape> {
+    class ShapeAdd : public TT<void, std::tuple<Out<void, Shape>>, ShapeAdd, ttg::typelist<Shape, Shape>> {
      public:
-      using baseT = TT<void, std::tuple<Out<void, Shape>>, ShapeAdd, Shape, Shape>;
+      using baseT = typename ShapeAdd::ttT;
       static constexpr const int owner = 0;  // where data resides
 
       ShapeAdd(Edge<void, Shape> &in1, Edge<void, Shape> &in2, Edge<void, Shape> &out)
@@ -330,9 +330,9 @@ namespace ttg {
     };
 
     // pushes all blocks given by the shape
-    class Push : public TT<void, std::tuple<Out<Key<2>, void>>, Push, Shape> {
+    class Push : public TT<void, std::tuple<Out<Key<2>, void>>, Push, ttg::typelist<Shape>> {
      public:
-      using baseT = TT<void, std::tuple<Out<Key<2>, void>>, Push, Shape>;
+      using baseT = typename Push::ttT;
       static constexpr const int owner = 0;  // where data resides
 
       Push(const char *label, Edge<void, Shape> &in, Edge<Key<2>, void> &out)

--- a/tests/movetest.cc
+++ b/tests/movetest.cc
@@ -42,8 +42,8 @@ class Value {
   ~Value() {}
 };
 
-class A : public TT<int, std::tuple<Out<int, Value>>, A, Value> {
-  using baseT = TT<int, std::tuple<Out<int, Value>>, A, Value>;
+class A : public TT<int, std::tuple<Out<int, Value>>, A, ttg::typelist<Value>> {
+  using baseT = A::ttT;
 
  public:
   A(const std::string& name) : baseT(name, {"input"}, {"result"}) {}
@@ -58,8 +58,8 @@ class A : public TT<int, std::tuple<Out<int, Value>>, A, Value> {
   ~A() { std::cout << " A destructor\n"; }
 };
 
-class Printer : public TT<int, std::tuple<>, Printer, Value> {
-  using baseT = TT<int, std::tuple<>, Printer, Value>;
+class Printer : public TT<int, std::tuple<>, Printer, ttg::typelist<Value>> {
+  using baseT = Printer::ttT;
 
  public:
   Printer() : baseT("printer", {"input"}, {}) {}

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -137,7 +137,7 @@ namespace tt_i_i_p {
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
        const std::string &name)
-        : baseT(inedges, outedges, name, {"int", "void"}, {}, Policy()) {}
+        : baseT(inedges, outedges, name, {"int"}, {}, Policy()) {}
 
     static constexpr const bool have_cuda_op = false;
 

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -7,8 +7,8 @@
 // {task_id,data} = {void, void}
 namespace tt_v_v {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, void> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, void>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -26,8 +26,8 @@ namespace tt_v_v {
 // {task_id,data} = {int, void}
 namespace tt_i_v {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, void> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, void>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -45,8 +45,8 @@ namespace tt_i_v {
 // {task_id,data} = {void, int}
 namespace tt_v_i {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, const int> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, const int>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -65,8 +65,8 @@ namespace tt_v_i {
 // {task_id,data} = {void, int, void}
 namespace tt_v_iv {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, const int, void> {
-    using baseT = ttg::TT<void, std::tuple<>, tt, const int, void>;
+  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int, void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -85,8 +85,8 @@ namespace tt_v_iv {
 // {task_id,data} = {int, int}
 namespace tt_i_i {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, const int> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, const int>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
@@ -104,8 +104,8 @@ namespace tt_i_i {
 // {task_id,data} = {int, int, void}
 namespace tt_i_iv {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, const int, void> {
-    using baseT = ttg::TT<int, std::tuple<>, tt, const int, void>;
+  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int, void>> {
+    using baseT = typename tt::ttT;
 
    public:
     tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -7,7 +7,7 @@
 // {task_id,data} = {void, void}
 namespace tt_v_v {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<void>> {
+  class tt : public ttg::TT<void, std::tuple<>, tt, ttg::typelist<void>> {
     using baseT = typename tt::ttT;
 
    public:
@@ -26,7 +26,7 @@ namespace tt_v_v {
 // {task_id,data} = {int, void}
 namespace tt_i_v {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<void>> {
+  class tt : public ttg::TT<int, std::tuple<>, tt, ttg::typelist<void>> {
     using baseT = typename tt::ttT;
 
    public:
@@ -45,7 +45,7 @@ namespace tt_i_v {
 // {task_id,data} = {void, int}
 namespace tt_v_i {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int>> {
+  class tt : public ttg::TT<void, std::tuple<>, tt, ttg::typelist<const int>> {
     using baseT = typename tt::ttT;
 
    public:
@@ -65,7 +65,7 @@ namespace tt_v_i {
 // {task_id,data} = {void, int, void}
 namespace tt_v_iv {
 
-  class tt : public ttg::TT<void, std::tuple<>, tt, std::tuple<const int, void>> {
+  class tt : public ttg::TT<void, std::tuple<>, tt, ttg::typelist<const int, void>> {
     using baseT = typename tt::ttT;
 
    public:
@@ -85,7 +85,7 @@ namespace tt_v_iv {
 // {task_id,data} = {int, int}
 namespace tt_i_i {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int>> {
+  class tt : public ttg::TT<int, std::tuple<>, tt, ttg::typelist<const int>> {
     using baseT = typename tt::ttT;
 
    public:
@@ -104,7 +104,7 @@ namespace tt_i_i {
 // {task_id,data} = {int, int, void}
 namespace tt_i_iv {
 
-  class tt : public ttg::TT<int, std::tuple<>, tt, std::tuple<const int, void>> {
+  class tt : public ttg::TT<int, std::tuple<>, tt, ttg::typelist<const int, void>> {
     using baseT = typename tt::ttT;
 
    public:

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -120,6 +120,33 @@ namespace tt_i_iv {
   };
 }  // namespace tt_i_iv
 
+// {task_id,data} = {int, int, void}
+namespace tt_i_i_p {
+
+  struct Policy : public ttg::TTPolicyBase<int> {
+
+    Policy() : TTPolicyBase() {}
+
+    int procmap(const int&) const { return 0; }
+
+  };
+
+  class tt : public ttg::TT<int, std::tuple<>, tt, ttg::typelist<const int>, Policy> {
+    using baseT = typename tt::ttT;
+
+   public:
+    tt(const typename baseT::input_edges_type &inedges, const typename baseT::output_edges_type &outedges,
+       const std::string &name)
+        : baseT(inedges, outedges, name, {"int", "void"}, {}, Policy()) {}
+
+    static constexpr const bool have_cuda_op = false;
+
+    void op(const int &key, const baseT::input_refs_tuple_type &data, baseT::output_terminals_type &outs) {}
+
+    ~tt() {}
+  };
+}  // namespace tt_i_iv
+
 TEST_CASE("TemplateTask", "[core]") {
   SECTION("constructors") {
     {  // void task id, void data
@@ -156,6 +183,13 @@ TEST_CASE("TemplateTask", "[core]") {
       CHECK_NOTHROW(std::make_unique<tt_i_i::tt>(ttg::edges(in), ttg::edges(), ""));
       CHECK_NOTHROW(
           ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges()));
+    }
+    {  // nonvoid task id, nonvoid data, w/ policies
+      ttg::Edge<int, int> in;
+      CHECK_NOTHROW(std::make_unique<tt_i_i_p::tt>(ttg::edges(in), ttg::edges(), ""));
+      CHECK_NOTHROW(
+          ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges(),
+                       ttg::make_policy<int>([](const int& key){ return 0; })));
     }
   }
 }

--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -190,6 +190,48 @@ TEST_CASE("TemplateTask", "[core]") {
       CHECK_NOTHROW(
           ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges(),
                        ttg::make_policy<int>([](const int& key){ return 0; })));
+
+          auto tt = ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges(),
+                       ttg::make_policy<int>([](const int& key){ return 0; }));
+          auto policy = tt->get_policy();
+    }
+  }
+
+  SECTION("policies") {
+    { // default policy
+      ttg::Edge<int, int> in;
+      auto tt = ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges());
+      auto policy = tt->get_policy();
+      CHECK(tt->procmap(0) == 0);
+      CHECK(tt->get_procmap()(0) == 0);
+      CHECK(policy.procmap(0) == 0);
+    }
+    { // custom procmap
+      ttg::Edge<int, int> in;
+      auto tt = ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges(),
+                             ttg::make_policy<int>([](const int& key){ return 0; }));
+      auto policy = tt->get_policy();
+      CHECK(tt->procmap(1) == 0);
+      CHECK(tt->get_procmap()(1) == 0);
+      CHECK(policy.procmap(1) == 0);
+      tt->set_priomap([](const int&){ return 0; });
+    }
+    { // custom all maps
+      ttg::Edge<int, int> in;
+      auto tt = ttg::make_tt([](const int &key, const int &datum, std::tuple<> &outs) {}, ttg::edges(in), ttg::edges(),
+                             ttg::make_policy<int>([](const int& key){ return 0; },
+                                                   [](const int& key){ return 0; },
+                                                   [](const int& key){ return 0; }));
+      auto policy = tt->get_policy();
+      CHECK(policy.procmap(1) == 0);
+      CHECK(tt->procmap(1) == 0);
+      CHECK(tt->get_procmap()(1) == 0);
+
+      CHECK(tt->priomap(1) == 0);
+      CHECK(tt->get_priomap()(1) == 0);
+
+      CHECK(tt->inlinemap(1) == 0);
+      CHECK(tt->get_inlinemap()(1) == 0);
     }
   }
 }

--- a/ttg/CMakeLists.txt
+++ b/ttg/CMakeLists.txt
@@ -18,6 +18,7 @@ set(ttg-util-headers
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/span.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/trace.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/tree.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/typelist.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/version.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/util/void.h
     )

--- a/ttg/CMakeLists.txt
+++ b/ttg/CMakeLists.txt
@@ -36,6 +36,7 @@ set(ttg-impl-headers
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/fwd.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/impl_selector.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/tt.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ttg/policies.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/reduce.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/run.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ttg/runtimes.h

--- a/ttg/ttg.h
+++ b/ttg/ttg.h
@@ -10,6 +10,7 @@
 #include "ttg/util/print.h"
 #include "ttg/util/trace.h"
 #include "ttg/util/void.h"
+#include "ttg/util/typelist.h"
 
 #include "ttg/base/keymap.h"
 #include "ttg/base/terminal.h"

--- a/ttg/ttg/base/keymap.h
+++ b/ttg/ttg/base/keymap.h
@@ -50,6 +50,20 @@ namespace ttg {
       operator()() const { return 0; }
     };
 
+    /// the default priority map implementation
+    template <typename keyT>
+    struct default_inlinemap_impl {
+      default_inlinemap_impl() = default;
+
+      template <typename Key = keyT>
+      std::enable_if_t<!meta::is_void_v<Key>,int>
+      operator()(const Key &key) const { return 0; }
+      template <typename Key = keyT>
+      std::enable_if_t<meta::is_void_v<Key>,int>
+      operator()() const { return 0; }
+    };
+
+
   }  // namespace detail
 
 } // namespace ttg

--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -10,6 +10,7 @@
 
 #include "ttg/base/terminal.h"
 #include "ttg/util/demangle.h"
+#include "ttg/util/trace.h"
 
 namespace ttg {
 

--- a/ttg/ttg/broadcast.h
+++ b/ttg/ttg/broadcast.h
@@ -12,6 +12,7 @@
 #include "ttg/tt.h"
 #include "ttg/util/tree.h"
 #include "ttg/world.h"
+#include "ttg/policies.h"
 
 namespace ttg {
 
@@ -34,7 +35,7 @@ namespace ttg {
                         World world = ttg::default_execution_context(), int max_key = -1,
                         Edge<int, Value> inout_l = Edge<int, Value>{}, Edge<int, Value> inout_r = Edge<int, Value>{})
         : baseT(edges(fuse(in, inout_l, inout_r)), edges(inout_l, inout_r, out), "BinaryTreeBroadcast",
-                {"in|inout_l|inout_r"}, {"inout_l", "inout_r", "out"}, world, [](int key) { return key; })
+                {"in|inout_l|inout_r"}, {"inout_l", "inout_r", "out"}, world, ttg::TTPolicyBase<int>([](int key) { return key; }))
         , tree_((max_key == -1 ? world.size() : max_key), root)
         , local_keys_(std::move(local_keys)) {}
 

--- a/ttg/ttg/broadcast.h
+++ b/ttg/ttg/broadcast.h
@@ -26,10 +26,9 @@ namespace ttg {
   ///
   template <typename Value, typename OutKey = int>
   class BinaryTreeBroadcast : public TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                                        BinaryTreeBroadcast<Value, OutKey>, Value> {
+                                        BinaryTreeBroadcast<Value, OutKey>, ttg::typelist<Value>> {
    public:
-    using baseT = TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                     BinaryTreeBroadcast<Value, OutKey>, Value>;
+    using baseT = typename BinaryTreeBroadcast::ttT;
 
     BinaryTreeBroadcast(Edge<int, Value> &in, Edge<OutKey, Value> &out, std::vector<OutKey> local_keys, int root = 0,
                         World world = ttg::default_execution_context(), int max_key = -1,

--- a/ttg/ttg/edge.h
+++ b/ttg/ttg/edge.h
@@ -138,6 +138,19 @@ namespace ttg {
     typedef std::tuple<typename edgesT::output_terminal_type...> type;
   };
 
+  namespace detail{
+    template<typename keyT, typename valuesT>
+    struct edges_tuple;
+
+    template<typename keyT, typename... valuesT>
+    struct edges_tuple<keyT, std::tuple<valuesT...>> {
+      using type = std::tuple<ttg::Edge<keyT, valuesT>...>;
+    };
+
+    template<typename keyT, typename valuesT>
+    using edges_tuple_t = typename edges_tuple<keyT, valuesT>::type;
+  } // namespace detail
+
 
 } // namespace ttg
 

--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -2,20 +2,21 @@
 #define TTG_MADNESS_FWD_H
 
 #include "ttg/fwd.h"
+#include "ttg/util/typelist.h"
 
 #include <future>
 
 namespace ttg_madness {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
   class TT;
 
   /// \internal the OG name
   template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
-  using Op [[deprecated("use TT instead")]] = TT<keyT, output_terminalsT, derivedT, input_valueTs...>;
+  using Op [[deprecated("use TT instead")]] = TT<keyT, output_terminalsT, derivedT, ttg::typelist<input_valueTs...>>;
   /// \internal the name in the ESPM2 paper
   template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
-  using TemplateTask = TT<keyT, output_terminalsT, derivedT, input_valueTs...>;
+  using TemplateTask = TT<keyT, output_terminalsT, derivedT, ttg::typelist<input_valueTs...>>;
 
   class WorldImpl;
 

--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -3,12 +3,14 @@
 
 #include "ttg/fwd.h"
 #include "ttg/util/typelist.h"
+#include "ttg/policies.h"
 
 #include <future>
 
 namespace ttg_madness {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>,
+            typename PolicyT = ttg::TTPolicyBase<keyT>>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -1004,17 +1004,17 @@ namespace ttg_madness {
     {}
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::detail::default_keymap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const std::string &name, const std::vector<std::string> &innames, const std::vector<std::string> &outnames,
-       ttg::detail::default_keymap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
         : TT(name, innames, outnames, ttg::default_execution_context(),
              policyT(std::move(keymap))) {}
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::detail::default_keymap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
        const std::vector<std::string> &innames, const std::vector<std::string> &outnames, ttg::World world,
-       ttg::detail::default_keymap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
     : TT(inedges, outedges, name, innames, outnames, world,
          policyT(std::move(keymap)))
     { }

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -1055,10 +1055,10 @@ namespace ttg_madness {
     }
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::detail::default_priomap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
        const std::vector<std::string> &innames, const std::vector<std::string> &outnames,
-       ttg::detail::default_priomap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
         : TT(inedges, outedges, name, innames, outnames, ttg::default_execution_context(),
              policyT(std::move(keymap))) {}
 

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -10,9 +10,8 @@
 //
 template <typename funcT, typename keyT, typename output_terminalsT, typename... input_valuesT>
 class CallableWrapTT : public TT<keyT, output_terminalsT,
-                                 CallableWrapTT<funcT, keyT, output_terminalsT, input_valuesT...>, input_valuesT...> {
-  using baseT =
-      TT<keyT, output_terminalsT, CallableWrapTT<funcT, keyT, output_terminalsT, input_valuesT...>, input_valuesT...>;
+                                 CallableWrapTT<funcT, keyT, output_terminalsT, input_valuesT...>, ttg::typelist<input_valuesT...>> {
+  using baseT = typename CallableWrapTT::ttT;
 
   using input_values_tuple_type = typename baseT::input_values_tuple_type;
   using input_refs_tuple_type = typename baseT::input_refs_tuple_type;
@@ -93,9 +92,8 @@ struct CallableWrapTTUnwrapTuple<funcT, keyT, output_terminalsT, std::tuple<inpu
 template <typename funcT, typename keyT, typename output_terminalsT, typename... input_valuesT>
 class CallableWrapTTArgs
     : public TT<keyT, output_terminalsT, CallableWrapTTArgs<funcT, keyT, output_terminalsT, input_valuesT...>,
-                input_valuesT...> {
-  using baseT = TT<keyT, output_terminalsT, CallableWrapTTArgs<funcT, keyT, output_terminalsT, input_valuesT...>,
-                   input_valuesT...>;
+                ttg::typelist<input_valuesT...>> {
+  using baseT = typename CallableWrapTTArgs::ttT;
 
   using input_values_tuple_type = typename baseT::input_values_tuple_type;
   using input_refs_tuple_type = typename baseT::input_refs_tuple_type;

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -46,11 +46,25 @@ class CallableWrapTT : public TT<keyT, output_terminalsT,
         func(std::forward<funcT_>(f)) {}
 
   template <typename funcT_, typename PolicyT_>
+  CallableWrapTT(funcT_ &&f, const input_edges_type &inedges, const output_edges_type &outedges,
+                 const std::string &name, const std::vector<std::string> &innames,
+                 const std::vector<std::string> &outnames)
+      : baseT(inedges, outedges, name, innames, outnames),
+        func(std::forward<funcT_>(f)) {}
+
+  template <typename funcT_, typename PolicyT_>
   CallableWrapTT(funcT_ &&f,
                  PolicyT_&& policy,
                  const std::string &name, const std::vector<std::string> &innames,
                  const std::vector<std::string> &outnames)
       : baseT(name, innames, outnames, std::forward<PolicyT>(policy)),
+        func(std::forward<funcT_>(f)) {}
+
+  template <typename funcT_>
+  CallableWrapTT(funcT_ &&f,
+                 const std::string &name, const std::vector<std::string> &innames,
+                 const std::vector<std::string> &outnames)
+      : baseT(name, innames, outnames),
         func(std::forward<funcT_>(f)) {}
 
   template <typename Key, typename ArgsTuple>

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -190,7 +190,8 @@ struct CallableWrapTTArgsUnwrapTuple<funcT, keyT, output_terminalsT, PolicyT, st
 //
 // case 1 (keyT != void): void op(const input_keyT&, std::tuple<input_valuesT&...>&&, std::tuple<output_terminalsT...>&)
 // case 2 (keyT == void): void op(std::tuple<input_valuesT&...>&&, std::tuple<output_terminalsT...>&)
-template <typename keyT, typename funcT, typename... input_valuesT, typename... output_edgesT, typename PolicyT>
+template <typename keyT, typename funcT, typename... input_valuesT, typename... output_edgesT,
+          typename PolicyT, typename = std::enable_if_t<ttg::detail::is_policy_v<keyT, PolicyT>>>
 auto make_tt_tpl(funcT &&func, const std::tuple<ttg::Edge<keyT, input_valuesT>...> &inedges,
                  const std::tuple<output_edgesT...> &outedges,
                  PolicyT&& policy, const std::string &name = "wrapper",
@@ -244,7 +245,7 @@ auto make_tt_tpl(funcT &&func, const std::tuple<ttg::Edge<keyT, input_valuesT>..
 //
 // input edges can contain at most one control input, and it must be last, if present
 template <typename keyT, typename funcT, typename... input_edge_valuesT, typename... output_edgesT,
-          typename PolicyT>
+          typename PolicyT, typename = std::enable_if_t<ttg::detail::is_policy_v<keyT, PolicyT>>>
 auto make_tt(funcT &&func, const std::tuple<ttg::Edge<keyT, input_edge_valuesT>...> &inedges,
              const std::tuple<output_edgesT...> &outedges, PolicyT&& policy,
              const std::string &name = "wrapper",

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -9,7 +9,7 @@
 
 namespace ttg_parsec {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>, typename Policies = TTPolicy>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>, typename Policies = ttg::TTPolicyBase<keyT>>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -2,20 +2,21 @@
 #define TTG_PARSEC_FWD_H
 
 #include "ttg/fwd.h"
+#include "ttg/util/typelist.h"
 
 #include <future>
 
 namespace ttg_parsec {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
   class TT;
 
   /// \internal the OG name
   template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
-  using Op [[deprecated("use TT instead")]] = TT<keyT, output_terminalsT, derivedT, input_valueTs...>;
+  using Op [[deprecated("use TT instead")]] = TT<keyT, output_terminalsT, derivedT, ttg::typelist<input_valueTs...>>;
   /// \internal the name in the ESPM2 paper
   template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
-  using TemplateTask = TT<keyT, output_terminalsT, derivedT, input_valueTs...>;
+  using TemplateTask = TT<keyT, output_terminalsT, derivedT, ttg::typelist<input_valueTs...>>;
 
   class WorldImpl;
 

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -3,12 +3,13 @@
 
 #include "ttg/fwd.h"
 #include "ttg/util/typelist.h"
+#include "ttg/policies.h"
 
 #include <future>
 
 namespace ttg_parsec {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>, typename Policies = TTPolicy>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -2684,28 +2684,40 @@ namespace ttg_parsec {
 
     /// process map setter
     /// Disabled if the used policy does not permit overriding the procmap.
-    template<typename ProcMap, typename Policy = PolicyT,
-             typename Enabler = std::enable_if_t<std::is_assignable_v<decltype(Policy::procmap), ProcMap>, void>>
+    template<typename ProcMap>
     void set_procmap(ProcMap &&km) {
-      policy.procmap = std::forward<ProcMap>(km);
+      if constexpr (std::is_assignable_v<decltype(PolicyT::procmap), ProcMap>) {
+        policy.procmap = std::forward<ProcMap>(km);
+      } else {
+        static_assert(std::is_assignable_v<decltype(PolicyT::procmap), ProcMap>,
+                      "Cannot assign process map of this TT");
+      }
     }
 
     /// priomap setter
     /// Disabled if the used policy does not permit overriding the procmap.
     /// @arg pm a function that maps a key to an integral priority value.
-    template<typename PrioMap, typename Policy = PolicyT,
-             typename Enabler = std::enable_if_t<std::is_assignable_v<typename Policy::priomap_t, PrioMap>, void>>
+    template<typename PrioMap>
     void set_priomap(PrioMap &&pm) {
-      policy.priomap = std::forward<PrioMap>(pm);
+      if constexpr (std::is_assignable_v<decltype(PolicyT::priomap), PrioMap>) {
+        policy.priomap = std::forward<PrioMap>(pm);
+      } else {
+        static_assert(std::is_assignable_v<decltype(PolicyT::priomap), PrioMap>,
+                      "Cannot assign priority map of this TT");
+      }
     }
 
     /// priomap setter
     /// Disabled if the used policy does not permit overriding the procmap.
     /// @arg pm a function that maps a key to an integral priority value.
-    template<typename InlineMap, typename Policy = PolicyT,
-             typename Enabler = std::enable_if_t<std::is_assignable_v<typename Policy::inlinemap_t, InlineMap>, void>>
-    void set_inlinemap(InlineMap &&pm) {
-      policy.inlinemap = std::forward<InlineMap>(pm);
+    template<typename InlineMap>
+    void set_inlinemap(InlineMap &&im) {
+      if constexpr (std::is_assignable_v<decltype(PolicyT::inlinemap), InlineMap>) {
+        policy.inlinemap = std::forward<InlineMap>(im);
+      } else {
+        static_assert(std::is_assignable_v<decltype(PolicyT::inlinemap), InlineMap>,
+                      "Cannot assign inline map of this TT");
+      }
     }
 
     const auto& get_policy() const {

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -2418,12 +2418,12 @@ namespace ttg_parsec {
     }
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const std::string &name,
        const std::vector<std::string> &innames,
        const std::vector<std::string> &outnames,
        ttg::World world,
-       ttg::meta::detail::keymap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
     : TT(name, innames, outnames, world, PolicyT(std::move(keymap)))
     {}
 
@@ -2444,11 +2444,11 @@ namespace ttg_parsec {
     {}
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const std::string &name,
        const std::vector<std::string> &innames,
        const std::vector<std::string> &outnames,
-       ttg::meta::detail::keymap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
     : TT(name, innames, outnames, ttg::default_execution_context(),
          PolicyT(std::move(keymap)))
     {}
@@ -2478,14 +2478,14 @@ namespace ttg_parsec {
 
 
     template <typename policyT = PolicyT,
-              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap<keyT>>>>
+              typename = std::enable_if_t<std::is_constructible_v<policyT, ttg::meta::detail::keymap_t<keyT>>>>
     TT(const input_edges_type &inedges,
        const output_edges_type &outedges,
        const std::string &name,
        const std::vector<std::string> &innames,
        const std::vector<std::string> &outnames,
        ttg::World world,
-       ttg::meta::detail::keymap<keyT> keymap)
+       ttg::meta::detail::keymap_t<keyT> keymap)
         : TT(inedges, outedges, name, innames, outnames, world,
              PolicyT(std::move(keymap)))
     { }

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -739,7 +739,7 @@ namespace ttg_parsec {
     };
   }  // namespace detail
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs, typename PolicyT>
   class TT : public ttg::TTBase, detail::ParsecTTBase {
    private:
     /// preconditions
@@ -748,6 +748,7 @@ namespace ttg_parsec {
     static_assert(ttg::meta::is_tuple_v<output_terminalsT>, "Second template argument for ttg::TT must be std::tuple containing the output terminal types");
     static_assert((ttg::meta::none_has_reference_v<input_valueTs>), "Input typelist cannot contain reference types");
     static_assert(ttg::meta::is_none_Void_v<input_valueTs>, "ttg::Void is for internal use only, do not use it");
+    static_assert(std::is_base_of_v<ttg::TTPolicyBase, PolicyT>, "The policy must be derived from TTPolicyBase");
 
     parsec_mempool_t mempools;
 
@@ -835,12 +836,26 @@ namespace ttg_parsec {
         make_finalize_argstream_fcts(std::make_index_sequence<numins>{});
 
     ttg::World world;
-    ttg::meta::detail::keymap_t<keyT> keymap;
-    ttg::meta::detail::keymap_t<keyT> priomap;
+    //ttg::meta::detail::keymap_t<keyT> keymap;
+    //ttg::meta::detail::keymap_t<keyT> priomap;
+    PolicyT policy;
+
     // For now use same type for unary/streaming input terminals, and stream reducers assigned at runtime
     ttg::meta::detail::input_reducers_t<input_tuple_type>
         input_reducers;  //!< Reducers for the input terminals (empty = expect single value)
     std::array<std::size_t, numins> static_stream_goal;
+
+    /** Legacy wrapper */
+    inline
+    int keymap(const keyT& key) const {
+      return policy.procmap(key);
+    }
+
+    /** Legacy wrapper */
+    inline
+    int priomap(const keyT& key) const {
+      return policy.priomap(key);
+    }
 
    public:
     ttg::World get_world() const { return world; }
@@ -2313,23 +2328,22 @@ namespace ttg_parsec {
     }
 
    public:
-    template <typename keymapT = ttg::detail::default_keymap<keyT>,
-              typename priomapT = ttg::detail::default_priomap<keyT>>
+    template <typename policyT = PolicyT>
     TT(const std::string &name, const std::vector<std::string> &innames, const std::vector<std::string> &outnames,
-       ttg::World world, keymapT &&keymap_ = keymapT(), priomapT &&priomap_ = priomapT())
+       ttg::World world, policyT&& policy)
         : ttg::TTBase(name, numins, numouts)
         , world(world)
         // if using default keymap, rebind to the given world
-        , keymap(std::is_same<keymapT, ttg::detail::default_keymap<keyT>>::value
-                     ? decltype(keymap)(ttg::detail::default_keymap<keyT>(world))
-                     : decltype(keymap)(std::forward<keymapT>(keymap_)))
-        , priomap(decltype(keymap)(std::forward<priomapT>(priomap_)))
+        , policy(std::forward<policyT>(policy))
         , static_stream_goal() {
       // Cannot call these in base constructor since terminals not yet constructed
       if (innames.size() != std::tuple_size<input_terminals_type>::value)
         throw std::logic_error("ttg_parsec::OP: #input names != #input terminals");
       if (outnames.size() != std::tuple_size<output_terminalsT>::value)
         throw std::logic_error("ttg_parsec::OP: #output names != #output terminals");
+
+      /* rebind the process map to the provided world */
+      policy.rebind(world);
 
       auto &world_impl = world.impl();
       world_impl.register_op(this);
@@ -2419,29 +2433,47 @@ namespace ttg_parsec {
                              NULL);
     }
 
-    template <typename keymapT = ttg::detail::default_keymap<keyT>,
-              typename priomapT = ttg::detail::default_priomap<keyT>>
+    template <typename policyT = PolicyT>
     TT(const std::string &name, const std::vector<std::string> &innames, const std::vector<std::string> &outnames,
-       keymapT &&keymap = keymapT(ttg::default_execution_context()), priomapT &&priomap = priomapT())
-        : TT(name, innames, outnames, ttg::default_execution_context(), std::forward<keymapT>(keymap),
-             std::forward<priomapT>(priomap)) {}
+       policyT&& policy)
+        : TT(name, innames, outnames, ttg::default_execution_context(), std::forward<policyT>(policy))
+    {}
 
-    template <typename keymapT = ttg::detail::default_keymap<keyT>,
-              typename priomapT = ttg::detail::default_priomap<keyT>>
+    template <typename policyT = PolicyT, typename = std::enable_if_t<std::is_default_constructible_v<policyT>>>
+    TT(const std::string &name, const std::vector<std::string> &innames, const std::vector<std::string> &outnames)
+        : TT(name, innames, outnames, ttg::default_execution_context(), policyT())
+    {}
+
+    template <typename policyT = PolicyT>
     TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
        const std::vector<std::string> &innames, const std::vector<std::string> &outnames, ttg::World world,
-       keymapT &&keymap_ = keymapT(), priomapT &&priomap = priomapT())
-        : TT(name, innames, outnames, world, std::forward<keymapT>(keymap_), std::forward<priomapT>(priomap)) {
+       policyT&& policy)
+        : TT(name, innames, outnames, world, std::forward<policyT>(policy)) {
       connect_my_inputs_to_incoming_edge_outputs(std::make_index_sequence<numins>{}, inedges);
       connect_my_outputs_to_outgoing_edge_inputs(std::make_index_sequence<numouts>{}, outedges);
     }
-    template <typename keymapT = ttg::detail::default_keymap<keyT>,
-              typename priomapT = ttg::detail::default_priomap<keyT>>
+
+    template <typename policyT = PolicyT, typename = std::enable_if_t<std::is_default_constructible_v<policyT>>>
+    TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
+       const std::vector<std::string> &innames, const std::vector<std::string> &outnames, ttg::World world)
+        : TT(inedges, outedges, name, innames, outnames, world, policyT()) {
+      connect_my_inputs_to_incoming_edge_outputs(std::make_index_sequence<numins>{}, inedges);
+      connect_my_outputs_to_outgoing_edge_inputs(std::make_index_sequence<numouts>{}, outedges);
+    }
+
+    template <typename policyT = PolicyT>
     TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
        const std::vector<std::string> &innames, const std::vector<std::string> &outnames,
-       keymapT &&keymap = keymapT(ttg::default_execution_context()), priomapT &&priomap = priomapT())
-        : TT(inedges, outedges, name, innames, outnames, ttg::default_execution_context(), std::forward<keymapT>(keymap),
-             std::forward<priomapT>(priomap)) {}
+       policyT&& policy)
+        : TT(inedges, outedges, name, innames, outnames, ttg::default_execution_context(),
+             std::forward<policyT>(policy))
+    {}
+
+    template <typename policyT = PolicyT, typename = std::enable_if_t<std::is_default_constructible_v<policyT>>>
+    TT(const input_edges_type &inedges, const output_edges_type &outedges, const std::string &name,
+       const std::vector<std::string> &innames, const std::vector<std::string> &outnames)
+        : TT(inedges, outedges, name, innames, outnames, ttg::default_execution_context(), policyT())
+    {}
 
     // Destructor checks for unexecuted tasks
     virtual ~TT() { release(); }
@@ -2561,23 +2593,54 @@ namespace ttg_parsec {
 
     /// keymap accessor
     /// @return the keymap
-    const decltype(keymap) &get_keymap() const { return keymap; }
+    auto get_keymap() const { return policy.get_procmap(); }
 
     /// keymap setter
-    template <typename Keymap>
+    /// Alias for \c set_procmap
+    /// Disabled if the used policy does not permit overriding the procmap.
+    template<typename Keymap>
     void set_keymap(Keymap &&km) {
-      keymap = km;
+      set_procmap(std::forward<Keymap>(km));
     }
+
+    /// process map accessor
+    /// @return the process map
+    auto get_procmap() const { return policy.get_procmap(); }
+
+    /// process map setter
+    /// Disabled if the used policy does not permit overriding the procmap.
+    template<typename ProcMap, typename Policy = PolicyT,
+             typename Enabler = std::enable_if_t<std::is_assignable_v<Policy::procmap_t, ProcMap>, void>>
+    void set_procmap(ProcMap &&km) {
+      policy.set_procmap(std::forward<Keymap>(km));
+    }
+
 
     /// priority map accessor
     /// @return the priority map
-    const decltype(priomap) &get_priomap() const { return priomap; }
+    auto get_priomap() const { return policy.get_priomap(); }
 
     /// priomap setter
+    /// Disabled if the used policy does not permit overriding the procmap.
     /// @arg pm a function that maps a key to an integral priority value.
-    template <typename Priomap>
-    void set_priomap(Priomap &&pm) {
-      priomap = pm;
+    template<typename PrioMap, typename Policy = PolicyT,
+             typename Enabler = std::enable_if_t<std::is_assignable_v<Policy::priomap_t, PrioMap>, void>>
+    void set_priomap(PrioMap &&pm) {
+      policy.set_priomap(std::forward<PrioMap>(pm));
+    }
+
+
+    /// priority map accessor
+    /// @return the priority map
+    auto get_inlinemap() const { return policy.get_inlinemap(); }
+
+    /// priomap setter
+    /// Disabled if the used policy does not permit overriding the procmap.
+    /// @arg pm a function that maps a key to an integral priority value.
+    template<typename InlineMap, typename Policy = PolicyT,
+             typename Enabler = std::enable_if_t<std::is_assignable_v<Policy::inlinemap_t, InlineMap>, void>>
+    void set_inlinemap(InlineMap &&pm) {
+      policy.set_inlinemap(std::forward<InlineMap>(pm));
     }
 
     // Register the static_op function to associate it to instance_id

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -25,6 +25,7 @@
 #include "ttg/util/print.h"
 #include "ttg/util/trace.h"
 #include "ttg/util/env.h"
+#include "ttg/util/typelist.h"
 
 #include "ttg/serialization/data_descriptor.h"
 
@@ -738,10 +739,16 @@ namespace ttg_parsec {
     };
   }  // namespace detail
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename... input_valueTs>
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs>
   class TT : public ttg::TTBase, detail::ParsecTTBase {
    private:
-    using ttT = TT<keyT, output_terminalsT, derivedT, input_valueTs...>;
+    /// preconditions
+    static_assert(ttg::detail::is_typelist_v<input_valueTs>, "The fourth template for ttg::TT must be a ttg::typelist containing the input types");
+    using input_tuple_type = typename input_valueTs::tuple_type;
+    static_assert(ttg::meta::is_tuple_v<output_terminalsT>, "Second template argument for ttg::TT must be std::tuple containing the output terminal types");
+    static_assert((ttg::meta::none_has_reference_v<input_valueTs>), "Input typelist cannot contain reference types");
+    static_assert(ttg::meta::is_none_Void_v<input_valueTs>, "ttg::Void is for internal use only, do not use it");
+
     parsec_mempool_t mempools;
 
     // check for a non-type member named have_cuda_op
@@ -750,8 +757,7 @@ namespace ttg_parsec {
 
     bool alive = true;
 
-   public:
-    static constexpr int numins = sizeof...(input_valueTs);                    // number of input arguments
+    static constexpr int numins = std::tuple_size_v<input_tuple_type>;            // number of input arguments
     static constexpr int numouts = std::tuple_size<output_terminalsT>::value;  // number of outputs
     static constexpr int numflows = std::max(numins, numouts);                 // max number of flows
 
@@ -764,22 +770,21 @@ namespace ttg_parsec {
       }
     }
 
-    using input_terminals_type = std::tuple<ttg::In<keyT, input_valueTs>...>;
-    using input_args_type = std::tuple<input_valueTs...>;
-    using input_edges_type = std::tuple<ttg::Edge<keyT, std::decay_t<input_valueTs>>...>;
-    static_assert(ttg::meta::is_none_Void_v<input_valueTs...>, "ttg::Void is for internal use only, do not use it");
+   public:
+    using ttT = TT;
+    using input_terminals_type = ttg::detail::input_terminals_tuple_t<keyT, input_tuple_type>;
+    using input_args_type = input_tuple_type;
+    using input_edges_type = ttg::detail::edges_tuple_t<keyT, ttg::meta::decayed_tuple_t<input_tuple_type>>;
     // if have data inputs and (always last) control input, convert last input to Void to make logic easier
-    using input_values_full_tuple_type = std::tuple<ttg::meta::void_to_Void_t<std::decay_t<input_valueTs>>...>;
+    using input_values_full_tuple_type = ttg::meta::void_to_Void_tuple_t<ttg::meta::decayed_tuple_t<input_tuple_type>>;
     using input_refs_full_tuple_type =
-        std::tuple<std::add_lvalue_reference_t<ttg::meta::void_to_Void_t<input_valueTs>>...>;
+        ttg::meta::add_lvalue_reference_tuple_t<ttg::meta::void_to_Void_tuple_t<input_tuple_type>>;
     using input_values_tuple_type =
-        std::conditional_t<ttg::meta::is_none_void_v<input_valueTs...>, input_values_full_tuple_type,
+        std::conditional_t<ttg::meta::is_none_void_v<input_valueTs>, input_values_full_tuple_type,
                            typename ttg::meta::drop_last_n<input_values_full_tuple_type, std::size_t{1}>::type>;
-    static_assert(!ttg::meta::is_any_void_v<input_values_tuple_type>);
     using input_refs_tuple_type =
-        std::conditional_t<ttg::meta::is_none_void_v<input_valueTs...>, input_refs_full_tuple_type,
+        std::conditional_t<ttg::meta::is_none_void_v<input_valueTs>, input_refs_full_tuple_type,
                            typename ttg::meta::drop_last_n<input_refs_full_tuple_type, std::size_t{1}>::type>;
-    using input_unwrapped_values_tuple_type = input_values_tuple_type;
     static constexpr int numinvals =
         std::tuple_size_v<input_refs_tuple_type>;  // number of input arguments with values (i.e. omitting the control
                                                    // input, if any)
@@ -833,7 +838,7 @@ namespace ttg_parsec {
     ttg::meta::detail::keymap_t<keyT> keymap;
     ttg::meta::detail::keymap_t<keyT> priomap;
     // For now use same type for unary/streaming input terminals, and stream reducers assigned at runtime
-    ttg::meta::detail::input_reducers_t<input_valueTs...>
+    ttg::meta::detail::input_reducers_t<input_tuple_type>
         input_reducers;  //!< Reducers for the input terminals (empty = expect single value)
     std::array<std::size_t, numins> static_stream_goal;
 
@@ -875,17 +880,18 @@ namespace ttg_parsec {
       }
 
       if constexpr (!ttg::meta::is_void_v<keyT> && !ttg::meta::is_empty_tuple_v<input_values_tuple_type>) {
-        input_refs_tuple_type input = make_tuple_of_ref_from_array(task, std::make_index_sequence<numinvals>{});
+        auto input = make_tuple_of_ref_from_array(task, std::make_index_sequence<numinvals>{});
         baseobj->template op<Space>(task->key, std::move(input), obj->output_terminals);
       } else if constexpr (!ttg::meta::is_void_v<keyT> && ttg::meta::is_empty_tuple_v<input_values_tuple_type>) {
         baseobj->template op<Space>(task->key, obj->output_terminals);
       } else if constexpr (ttg::meta::is_void_v<keyT> && !ttg::meta::is_empty_tuple_v<input_values_tuple_type>) {
-        input_refs_tuple_type input = make_tuple_of_ref_from_array(task, std::make_index_sequence<numinvals>{});
+        auto input = make_tuple_of_ref_from_array(task, std::make_index_sequence<numinvals>{});
         baseobj->template op<Space>(std::move(input), obj->output_terminals);
       } else if constexpr (ttg::meta::is_void_v<keyT> && ttg::meta::is_empty_tuple_v<input_values_tuple_type>) {
         baseobj->template op<Space>(obj->output_terminals);
-      } else
+      } else {
         abort();
+      }
       parsec_ttg_caller = NULL;
 
       if (obj->tracing()) {
@@ -1637,7 +1643,7 @@ namespace ttg_parsec {
     template <typename Key = keyT>
     std::enable_if_t<ttg::meta::is_void_v<Key>, void> set_arg() {
       static_assert(ttg::meta::is_empty_tuple_v<input_refs_tuple_type>,
-                    "logic error: set_arg (case 3) called but input_refs_tuple_type is nonempty");
+                    "logic error: set_arg (case 6) called but input_refs_tuple_type is nonempty");
 
       const auto owner = keymap();
       if (owner == ttg_default_execution_context().rank()) {
@@ -2438,7 +2444,7 @@ namespace ttg_parsec {
              std::forward<priomapT>(priomap)) {}
 
     // Destructor checks for unexecuted tasks
-    ~TT() { release(); }
+    virtual ~TT() { release(); }
 
     static void ht_iter_cb(void *item, void *cb_data) {
       task_t *task = (task_t *)item;
@@ -2451,6 +2457,10 @@ namespace ttg_parsec {
     }
 
     virtual void release() override {
+      do_release();
+    }
+
+    void do_release() {
       if (!alive) {
         return;
       }
@@ -2474,6 +2484,7 @@ namespace ttg_parsec {
       }
       world.impl().deregister_op(this);
     }
+
 
     static constexpr const ttg::Runtime runtime = ttg::Runtime::PaRSEC;
 

--- a/ttg/ttg/policies.h
+++ b/ttg/ttg/policies.h
@@ -4,293 +4,8 @@
 
 #include "ttg/base/keymap.h"
 #include "ttg/util/meta.h"
-#include "ttg/world.h"
 
 namespace ttg {
-
-  /**
-   * The default policy for process maps that allows dynamically
-   * setting the mapping function.
-   *
-   * Derive from this class to acquire the default behavior in your
-   * custom policy class.
-   */
-  template<typename Key>
-  struct TTProcmapPolicy {
-
-    using procmap_t = typename ttg::meta::detail::keymap_t<Key>;
-
-    procmap_t m_procmap;
-
-    /**
-     * The process mapping. Defaults to round-robin process mapping.
-     *
-     * This function may not be overriden.
-     *
-     * \sa ttg::detail::default_keymap
-     */
-    int procmap(const Key& key) {
-      return m_procmap(key);
-    }
-
-    virtual void rebind_procmap(ttg::World& world) final {
-      m_procmap = ttg::detail::default_keymap<Key>(world);
-    }
-
-    /**
-     * Dynamically override the default process map by setting the mapping callback.
-     */
-    template<typename ProcMap>
-    int set_procmap(ProcMap&& pm) {
-      m_procmap = std::forward<ProcMap>(pm);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const procmap_t& get_procmap() const {
-      return m_procmap;
-    }
-
-  };
-
-
-  /**
-   * Specialization of \sa ttg::TTProcmapPolicy for key type \c void.
-   */
-  template<>
-  struct TTProcmapPolicy<void> {
-
-    using procmap_t = typename ttg::meta::detail::keymap_t<void>;
-
-    procmap_t m_procmap;
-
-    /**
-     * The process mapping. Defaults to round-robin process mapping.
-     *
-     * This function may not be overriden.
-     *
-     * \sa ttg::detail::default_keymap
-     */
-    int procmap() const {
-      return m_procmap();
-    }
-
-    virtual void rebind_procmap(ttg::World& world) final {
-      m_procmap = ttg::detail::default_keymap<void>(world);
-    }
-
-    /**
-     * Dynamically override the default process map by setting the mapping callback.
-     */
-    template<typename ProcMap>
-    int set_procmap(ProcMap&& pm) {
-      m_procmap = std::forward<ProcMap>(pm);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const procmap_t& get_procmap() const {
-      return m_procmap;
-    }
-  };
-
-
-
-  /**
-   * The default policy for priority maps that allows dynamically
-   * setting the mapping function.
-   *
-   * Derive from this class to acquire the default behavior in your
-   * custom policy class.
-   */
-  template<typename Key>
-  struct TTPriomapPolicy {
-
-    using priomap_t = typename ttg::meta::detail::keymap_t<Key>;
-
-    priomap_t m_priomap;
-
-    /**
-     * The priority mapping. Defaults to priority 0.
-     *
-     * This function may not be overriden.
-     *
-     * \sa ttg::detail::default_keymap
-     */
-    int priomap(const Key& key) const {
-      return m_priomap(key);
-    }
-
-    /**
-     * Dynamically override the default priority map by setting the mapping callback.
-     */
-    template<typename PrioMap>
-    int set_priomap(PrioMap&& pm) {
-      m_priomap = std::forward<PrioMap>(pm);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const priomap_t& get_priomap() const {
-      return m_priomap;
-    }
-  };
-
-  /**
-   * Specialization of \sa ttg::TTPriomapPolicy for key type \c void.
-   */
-  template<>
-  struct TTPriomapPolicy<void> {
-
-    using priomap_t = typename ttg::meta::detail::keymap_t<void>;
-
-    priomap_t m_priomap;
-
-    /**
-     * The priority mapping. Defaults to priority 0.
-     *
-     * This function may not be overriden.
-     *
-     * \sa ttg::detail::default_keymap
-     */
-    int priomap() const {
-      return m_priomap();
-    }
-
-    /**
-     * Dynamically override the default priority map by setting the mapping callback.
-     */
-    template<typename PrioMap>
-    int set_priomap(PrioMap&& pm) {
-      m_priomap = std::forward<PrioMap>(pm);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const priomap_t& get_priomap() const {
-      return m_priomap;
-    }
-  };
-
-
-  /**
-   * The default policy for priority maps that allows dynamically
-   * setting the mapping function.
-   *
-   * Derive from this class to acquire the default behavior in your
-   * custom policy class.
-   */
-  template<typename Key>
-  struct TTInlinePolicy {
-
-    using inlinemap_t = typename ttg::meta::detail::keymap_t<Key>;
-
-    inlinemap_t m_inlinemap = [](){ return 0; };
-
-    /**
-     * The inline mapping. Defaults to no inlining.
-     *
-     * Whether a task can be executed inline, i.e., without dispatching the
-     * task to a scheduler first. The task will be executed in the send or
-     * broadcast call once all inputs have been satisfied. The returned value
-     * denotes the maximum recirsion depth, i.e., how many tasks may be executed
-     * inline consecutively. Zero denotes no inlining. This is the default.
-     *
-     * This function may not be overriden.
-     */
-    int inlinemap(const Key& key) const {
-      return m_inlinemap(key);
-    }
-
-    /**
-     * Dynamically override the default inlining map by setting the mapping callback.
-     */
-    template<typename InlineMap>
-    int set_priomap(InlineMap&& im) {
-      m_inlinemap = std::forward<InlineMap>(im);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const inlinemap_t& get_inlinemap() const {
-      return m_inlinemap;
-    }
-  };
-
-  /**
-   * Specialization of \sa ttg::TTInlinePolicy for key type \c void.
-   */
-  template<>
-  struct TTInlinePolicy<void> {
-
-    using inlinemap_t = typename ttg::meta::detail::keymap_t<void>;
-    inlinemap_t m_inlinemap = [](){ return 0; };
-
-    /**
-     * The inline mapping. Defaults to no inlining.
-     *
-     * This function may not be overriden.
-     *
-     * \sa ttg::detail::default_keymap
-     */
-    virtual int inlinemap() final {
-      return m_inlinemap();
-    }
-
-    /**
-     * Dynamically override the default inlining map by setting the mapping callback.
-     */
-    template<typename InlineMap>
-    int set_priomap(InlineMap&& im) {
-      m_inlinemap = std::forward<InlineMap>(im);
-    }
-
-    /**
-     * Query the dynamic mapping function.
-     */
-    const inlinemap_t& get_inlinemap() {
-      return m_inlinemap;
-    }
-  };
-
-  /**
-   * Policy class used to control aspects of TT execution:
-   *  * Process mapping: maps a key identifying a task to a process to run on.
-   *  * Priority mapping: assigns a priority (positive integer) to a task identified by a key.
-   *                      Higher values increase the task's priority.
-   *  * Inline mapping: whether a task can be executed inline, i.e., without dispatching the
-   *                    task to a scheduler first. The task will be executed in the send or
-   *                    broadcast call. The returned value denotes the maximum recirsion depth,
-   *                    i.e., how many tasks may be executed inline consecutively. Zero denotes
-   *                    no inlining. This is the default.
-   *
-   * Custom policy classes can be created by implementing the \c procmap, \c priomap, and
-   * \c inlinemap functions. Defaults for the various mappings can be obtained by
-   * inheriting from \c TTProcmapPolicy, \c TTPriomapPolicy, or \c TTInlinePolicy.
-   *
-   * This policy is composed of the default policies and may itself act as base class.
-   * If inheriting from \c TTPolicy and the \c priomap, \c procmap, or \c inlinemap are
-   * overriden then TTG will not allow setting the respective dynamic mapping function on a TT.
-   * Inheriting from TTPolicy allows for custom policies to stay forward compatible
-   * by including support for future policy extensions. However, inheriting from
-   * \c TTProcmapPolicy, \c TTPriomapPolicy, \c TTInlinePolicy, or \c TTPolicy
-   * will include the base class infrastructure that may not be needed in the
-   * custom policy implementation.
-   *
-   * \sa ttg::TTProcmapPolicy
-   * \sa ttg::TTPriomapPolicy
-   * \sa ttg::TTInlinePolicy
-   *
-   */
-  template<typename Key>
-  struct TTPolicy
-  : public TTProcmapPolicy<Key>, TTPriomapPolicy<Key>, TTInlinePolicy<Key>
-  { };
 
   namespace detail {
     template<typename MapT>
@@ -369,33 +84,34 @@ namespace ttg {
     template<typename ProcMap_ = ProcMap,
              typename PrioMap_ = PrioMap,
              typename InlineMap_ = InlineMap,
-             typename Enabler = std::enable_if_t<is_default_procmap &&
-                                                 is_default_priomap &&
-                                                 is_default_inlinemap>>
+             typename = std::enable_if_t<detail::is_default_keymap_v<ProcMap_> &&
+                                         detail::is_default_keymap_v<PrioMap_> &&
+                                         detail::is_default_keymap_v<InlineMap_>>>
     TTPolicyBase()
-    : TTPolicyBase(ttg::meta::detail::keymap_t<Key>(ttg::detail::default_keymap<Key>()),
-                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap<Key>()),
-                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+    : TTPolicyBase(ttg::meta::detail::keymap_t<Key>(ttg::detail::default_keymap_impl<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap_impl<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap_impl<Key>()))
     { }
 
     template<typename ProcMap_,
              typename PrioMap_ = PrioMap,
              typename InlineMap_ = InlineMap,
-             typename Enabler = std::enable_if_t<is_default_priomap && is_default_inlinemap>>
+             typename = std::enable_if_t<detail::is_default_keymap_v<PrioMap_> &&
+                                         detail::is_default_keymap_v<InlineMap_>>>
     TTPolicyBase(ProcMap_&& procmap)
     : TTPolicyBase(std::forward<ProcMap_>(procmap),
-                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap<Key>()),
-                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap_impl<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap_impl<Key>()))
     { }
 
     template<typename ProcMap_,
              typename PrioMap_,
              typename InlineMap_ = InlineMap,
-             typename Enabler = std::enable_if_t<is_default_inlinemap>>
+             typename = std::enable_if_t<detail::is_default_keymap_v<InlineMap_>>>
     TTPolicyBase(ProcMap_&& procmap, PrioMap_&& priomap)
     : TTPolicyBase(std::forward<ProcMap_>(procmap),
                    std::forward<PrioMap_>(priomap),
-                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap_impl<Key>()))
     { }
 
     template<typename ProcMap_, typename PrioMap_, typename InlineMap_>
@@ -411,10 +127,11 @@ namespace ttg {
      * Rebind the default process map to the provided world, if the process map
      * is the default map.
      */
+    template<typename WorldT>
     inline
-    void rebind(ttg::World& world) {
+    void rebind(const WorldT& world) {
       if constexpr (is_default_procmap) {
-        procmap = ttg::detail::default_keymap<Key>(world);
+        procmap = ttg::detail::default_keymap_impl<Key>(world.size());
       }
     }
 
@@ -430,37 +147,6 @@ namespace ttg {
       return inlinemap;
     }
   };
-
-
-  namespace detail {
-    template<typename Key, typename ProcMap, typename PrioMap, typename InlineMap>
-    struct TTPolicyWrapper {
-      ProcMap procmap;
-      PrioMap priomap;
-      InlineMap inlinemap;
-
-      template<typename ProcMap_, typename PrioMap_, typename InlineMap_>
-      TTPolicyWrapper(ProcMap_&& procmap = ttg::detail::default_keymap<Key>(),
-                      PrioMap_&& priomap = ttg::detail::default_priomap<Key>(),
-                      InlineMap_&& im = ttg::detail::default_inlinemap<Key>())
-      : procmap(std::forward<ProcMap_>(procmap)),
-        priomap(std::forward<PrioMap_>(priomap)),
-        inlinemap(std::forward<InlineMap_>(im))
-      { }
-
-      auto get_procmap() {
-        return procmap;
-      }
-
-      auto get_priomap() {
-        return priomap;
-      }
-
-      auto get_inlinemap() {
-        return inlinemap;
-      }
-    };
-  } // namespace detail
 
   /**
    * Helper function to create a TT policy from arbitrary function objects.
@@ -486,6 +172,72 @@ namespace ttg {
   {
     return TTPolicyBase<Key, Args...>(std::forward<Args>(args)...);
   }
+
+
+  namespace detail {
+
+    /**
+     * Generate traits to check policy objects for procmap(), priomap(), and inlinemap() members
+     */
+#define TTG_POLICY_CREATE_CHECK_FOR(_Pol)                                        \
+    /* specialization that does the checking */                                  \
+    template<typename KeyT, typename PolicyT>                                    \
+    struct has_##_Pol {                                                          \
+    private:                                                                     \
+        template<typename T>                                                     \
+        static constexpr auto check(T*)                                          \
+        -> typename                                                              \
+            std::is_same<                                                        \
+                /* policy function take a key and return int */                  \
+                decltype( std::declval<T>(). _Pol ( std::declval<KeyT>() ) ),    \
+                int                                                              \
+            >::type;                                                             \
+        template<typename>                                                       \
+        static constexpr std::false_type check(...);                             \
+        typedef decltype(check<PolicyT>(0)) type;                                \
+    public:                                                                      \
+        static constexpr bool value = type::value;                               \
+    };                                                                           \
+    template<typename PolicyT>                                                   \
+    struct has_##_Pol<void, PolicyT> {                                           \
+    private:                                                                     \
+        template<typename T>                                                     \
+        static constexpr auto check(T*)                                          \
+        -> typename                                                              \
+            std::is_same<                                                        \
+                /* policy function for void simply return int */                 \
+                decltype( std::declval<T>(). _Pol ( ) ),                         \
+                int                                                              \
+            >::type;                                                             \
+        template<typename>                                                       \
+        static constexpr std::false_type check(...);                             \
+        typedef decltype(check<PolicyT>(0)) type;                                \
+    public:                                                                      \
+        static constexpr bool value = type::value;                               \
+    };                                                                           \
+    template<typename KeyT, typename PolicyT>                                    \
+    constexpr const bool has_##_Pol ## _v = has_ ## _Pol<KeyT, PolicyT>::value;
+
+    TTG_POLICY_CREATE_CHECK_FOR(procmap);
+    TTG_POLICY_CREATE_CHECK_FOR(priomap);
+    TTG_POLICY_CREATE_CHECK_FOR(inlinemap);
+
+    /** Whether PolicyT is a valid policy object using KeyT */
+    template<typename KeyT, typename PolicyT>
+    struct is_policy {
+      static constexpr bool value = has_procmap_v<KeyT, PolicyT> &&
+                                    has_priomap_v<KeyT, PolicyT> &&
+                                    has_inlinemap_v<KeyT, PolicyT>;
+    };
+
+    /** Whether PolicyT is a valid policy object using KeyT */
+    template<typename KeyT, typename PolicyT>
+    constexpr const bool is_policy_v = is_policy<KeyT, PolicyT>::value;
+
+    /* sanity base check */
+    static_assert(is_policy_v<int, ttg::TTPolicyBase<int>>);
+  } // namespace detail
+
 
 } // namespace ttg
 

--- a/ttg/ttg/policies.h
+++ b/ttg/ttg/policies.h
@@ -82,10 +82,12 @@ namespace ttg {
    * \sa ttg::make_policy
    */
   template<typename Key,
-           typename ProcMap = typename ttg::meta::detail::keymap<Key>,
-           typename PrioMap = typename ttg::meta::detail::keymap<Key>,
-           typename InlineMap = typename ttg::meta::detail::keymap<Key>>
+           typename ProcMap = typename ttg::meta::detail::keymap_t<Key>,
+           typename PrioMap = typename ttg::meta::detail::keymap_t<Key>,
+           typename InlineMap = typename ttg::meta::detail::keymap_t<Key>>
   struct TTPolicyBase {
+
+    using PolicyBaseT = TTPolicyBase<Key, ProcMap, PrioMap, InlineMap>;
 
     using procmap_t = detail::map_type_t<ProcMap>;
     using priomap_t = detail::map_type_t<PrioMap>;
@@ -109,7 +111,8 @@ namespace ttg {
     template<typename ProcMap_,
              typename PrioMap_ = PrioMap,
              typename InlineMap_ = InlineMap,
-             typename = std::enable_if_t<std::is_default_constructible_v<PrioMap_> &&
+             typename = std::enable_if_t<std::is_constructible_v<procmap_t, ProcMap_> &&
+                                         std::is_default_constructible_v<PrioMap_> &&
                                          std::is_default_constructible_v<InlineMap_>>>
     TTPolicyBase(ProcMap_&& procmap)
     : procmap(std::forward<ProcMap_>(procmap))
@@ -133,8 +136,8 @@ namespace ttg {
     , inlinemap(std::forward<InlineMap_>(im))
     { }
 
-    TTPolicyBase(const TTPolicyBase&) = default;
-    TTPolicyBase(TTPolicyBase&&) = default;
+    TTPolicyBase(const PolicyBaseT&) = default;
+    TTPolicyBase(PolicyBaseT&&) = default;
 
   };
 
@@ -211,14 +214,14 @@ namespace ttg {
         if constexpr (procmap_is_std_function) {
           if (!m_policy.procmap) {
             /* create a std::function from the default implementation */
-            return ttg::meta::detail::keymap<Key>(m_default_procmap);
+            return ttg::meta::detail::keymap_t<Key>(m_default_procmap);
           } else {
             /* return the current std::function */
             return m_policy.procmap;
           }
         } else {
           /* wrap whatever the procmap is in a lambda */
-          return ttg::meta::detail::keymap<Key>([=](const Key& key){ return m_policy.procmap(key); });
+          return ttg::meta::detail::keymap_t<Key>([=](const Key& key){ return m_policy.procmap(key); });
         }
       }
 
@@ -230,14 +233,14 @@ namespace ttg {
         if constexpr (priomap_is_std_function) {
           if (!m_policy.priomap) {
             /* create a std::function from the default implementation */
-            return ttg::meta::detail::keymap<Key>(m_default_priomap);
+            return ttg::meta::detail::keymap_t<Key>(m_default_priomap);
           } else {
             /* return the current std::function */
             return m_policy.priomap;
           }
         } else {
           /* wrap whatever the procmap is in a lambda */
-          return ttg::meta::detail::keymap<Key>([=](const Key& key){ return m_policy.priomap(key); });
+          return ttg::meta::detail::keymap_t<Key>([=](const Key& key){ return m_policy.priomap(key); });
         }
       }
 
@@ -245,14 +248,14 @@ namespace ttg {
         if constexpr (inlinemap_is_std_function) {
           if (!m_policy.inlinemap) {
             /* create a std::function from the default implementation */
-            return ttg::meta::detail::keymap<Key>(m_default_inlinemap);
+            return ttg::meta::detail::keymap_t<Key>(m_default_inlinemap);
           } else {
             /* return the current std::function */
             return m_policy.inlinemap;
           }
         } else {
           /* wrap whatever the procmap is in a lambda */
-          return ttg::meta::detail::keymap<Key>([=](const Key& key){ return m_policy.inlinemap(key); });
+          return ttg::meta::detail::keymap_t<Key>([=](const Key& key){ return m_policy.inlinemap(key); });
         }
       }
 

--- a/ttg/ttg/policies.h
+++ b/ttg/ttg/policies.h
@@ -133,6 +133,9 @@ namespace ttg {
     , inlinemap(std::forward<InlineMap_>(im))
     { }
 
+    TTPolicyBase(const TTPolicyBase&) = default;
+    TTPolicyBase(TTPolicyBase&&) = default;
+
   };
 
   namespace detail {

--- a/ttg/ttg/policies.h
+++ b/ttg/ttg/policies.h
@@ -1,0 +1,492 @@
+
+#ifndef TTG_POLICIES_H
+#define TTG_POLICIES_H
+
+#include "ttg/base/keymap.h"
+#include "ttg/util/meta.h"
+#include "ttg/world.h"
+
+namespace ttg {
+
+  /**
+   * The default policy for process maps that allows dynamically
+   * setting the mapping function.
+   *
+   * Derive from this class to acquire the default behavior in your
+   * custom policy class.
+   */
+  template<typename Key>
+  struct TTProcmapPolicy {
+
+    using procmap_t = typename ttg::meta::detail::keymap_t<Key>;
+
+    procmap_t m_procmap;
+
+    /**
+     * The process mapping. Defaults to round-robin process mapping.
+     *
+     * This function may not be overriden.
+     *
+     * \sa ttg::detail::default_keymap
+     */
+    int procmap(const Key& key) {
+      return m_procmap(key);
+    }
+
+    virtual void rebind_procmap(ttg::World& world) final {
+      m_procmap = ttg::detail::default_keymap<Key>(world);
+    }
+
+    /**
+     * Dynamically override the default process map by setting the mapping callback.
+     */
+    template<typename ProcMap>
+    int set_procmap(ProcMap&& pm) {
+      m_procmap = std::forward<ProcMap>(pm);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const procmap_t& get_procmap() const {
+      return m_procmap;
+    }
+
+  };
+
+
+  /**
+   * Specialization of \sa ttg::TTProcmapPolicy for key type \c void.
+   */
+  template<>
+  struct TTProcmapPolicy<void> {
+
+    using procmap_t = typename ttg::meta::detail::keymap_t<void>;
+
+    procmap_t m_procmap;
+
+    /**
+     * The process mapping. Defaults to round-robin process mapping.
+     *
+     * This function may not be overriden.
+     *
+     * \sa ttg::detail::default_keymap
+     */
+    int procmap() const {
+      return m_procmap();
+    }
+
+    virtual void rebind_procmap(ttg::World& world) final {
+      m_procmap = ttg::detail::default_keymap<void>(world);
+    }
+
+    /**
+     * Dynamically override the default process map by setting the mapping callback.
+     */
+    template<typename ProcMap>
+    int set_procmap(ProcMap&& pm) {
+      m_procmap = std::forward<ProcMap>(pm);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const procmap_t& get_procmap() const {
+      return m_procmap;
+    }
+  };
+
+
+
+  /**
+   * The default policy for priority maps that allows dynamically
+   * setting the mapping function.
+   *
+   * Derive from this class to acquire the default behavior in your
+   * custom policy class.
+   */
+  template<typename Key>
+  struct TTPriomapPolicy {
+
+    using priomap_t = typename ttg::meta::detail::keymap_t<Key>;
+
+    priomap_t m_priomap;
+
+    /**
+     * The priority mapping. Defaults to priority 0.
+     *
+     * This function may not be overriden.
+     *
+     * \sa ttg::detail::default_keymap
+     */
+    int priomap(const Key& key) const {
+      return m_priomap(key);
+    }
+
+    /**
+     * Dynamically override the default priority map by setting the mapping callback.
+     */
+    template<typename PrioMap>
+    int set_priomap(PrioMap&& pm) {
+      m_priomap = std::forward<PrioMap>(pm);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const priomap_t& get_priomap() const {
+      return m_priomap;
+    }
+  };
+
+  /**
+   * Specialization of \sa ttg::TTPriomapPolicy for key type \c void.
+   */
+  template<>
+  struct TTPriomapPolicy<void> {
+
+    using priomap_t = typename ttg::meta::detail::keymap_t<void>;
+
+    priomap_t m_priomap;
+
+    /**
+     * The priority mapping. Defaults to priority 0.
+     *
+     * This function may not be overriden.
+     *
+     * \sa ttg::detail::default_keymap
+     */
+    int priomap() const {
+      return m_priomap();
+    }
+
+    /**
+     * Dynamically override the default priority map by setting the mapping callback.
+     */
+    template<typename PrioMap>
+    int set_priomap(PrioMap&& pm) {
+      m_priomap = std::forward<PrioMap>(pm);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const priomap_t& get_priomap() const {
+      return m_priomap;
+    }
+  };
+
+
+  /**
+   * The default policy for priority maps that allows dynamically
+   * setting the mapping function.
+   *
+   * Derive from this class to acquire the default behavior in your
+   * custom policy class.
+   */
+  template<typename Key>
+  struct TTInlinePolicy {
+
+    using inlinemap_t = typename ttg::meta::detail::keymap_t<Key>;
+
+    inlinemap_t m_inlinemap = [](){ return 0; };
+
+    /**
+     * The inline mapping. Defaults to no inlining.
+     *
+     * Whether a task can be executed inline, i.e., without dispatching the
+     * task to a scheduler first. The task will be executed in the send or
+     * broadcast call once all inputs have been satisfied. The returned value
+     * denotes the maximum recirsion depth, i.e., how many tasks may be executed
+     * inline consecutively. Zero denotes no inlining. This is the default.
+     *
+     * This function may not be overriden.
+     */
+    int inlinemap(const Key& key) const {
+      return m_inlinemap(key);
+    }
+
+    /**
+     * Dynamically override the default inlining map by setting the mapping callback.
+     */
+    template<typename InlineMap>
+    int set_priomap(InlineMap&& im) {
+      m_inlinemap = std::forward<InlineMap>(im);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const inlinemap_t& get_inlinemap() const {
+      return m_inlinemap;
+    }
+  };
+
+  /**
+   * Specialization of \sa ttg::TTInlinePolicy for key type \c void.
+   */
+  template<>
+  struct TTInlinePolicy<void> {
+
+    using inlinemap_t = typename ttg::meta::detail::keymap_t<void>;
+    inlinemap_t m_inlinemap = [](){ return 0; };
+
+    /**
+     * The inline mapping. Defaults to no inlining.
+     *
+     * This function may not be overriden.
+     *
+     * \sa ttg::detail::default_keymap
+     */
+    virtual int inlinemap() final {
+      return m_inlinemap();
+    }
+
+    /**
+     * Dynamically override the default inlining map by setting the mapping callback.
+     */
+    template<typename InlineMap>
+    int set_priomap(InlineMap&& im) {
+      m_inlinemap = std::forward<InlineMap>(im);
+    }
+
+    /**
+     * Query the dynamic mapping function.
+     */
+    const inlinemap_t& get_inlinemap() {
+      return m_inlinemap;
+    }
+  };
+
+  /**
+   * Policy class used to control aspects of TT execution:
+   *  * Process mapping: maps a key identifying a task to a process to run on.
+   *  * Priority mapping: assigns a priority (positive integer) to a task identified by a key.
+   *                      Higher values increase the task's priority.
+   *  * Inline mapping: whether a task can be executed inline, i.e., without dispatching the
+   *                    task to a scheduler first. The task will be executed in the send or
+   *                    broadcast call. The returned value denotes the maximum recirsion depth,
+   *                    i.e., how many tasks may be executed inline consecutively. Zero denotes
+   *                    no inlining. This is the default.
+   *
+   * Custom policy classes can be created by implementing the \c procmap, \c priomap, and
+   * \c inlinemap functions. Defaults for the various mappings can be obtained by
+   * inheriting from \c TTProcmapPolicy, \c TTPriomapPolicy, or \c TTInlinePolicy.
+   *
+   * This policy is composed of the default policies and may itself act as base class.
+   * If inheriting from \c TTPolicy and the \c priomap, \c procmap, or \c inlinemap are
+   * overriden then TTG will not allow setting the respective dynamic mapping function on a TT.
+   * Inheriting from TTPolicy allows for custom policies to stay forward compatible
+   * by including support for future policy extensions. However, inheriting from
+   * \c TTProcmapPolicy, \c TTPriomapPolicy, \c TTInlinePolicy, or \c TTPolicy
+   * will include the base class infrastructure that may not be needed in the
+   * custom policy implementation.
+   *
+   * \sa ttg::TTProcmapPolicy
+   * \sa ttg::TTPriomapPolicy
+   * \sa ttg::TTInlinePolicy
+   *
+   */
+  template<typename Key>
+  struct TTPolicy
+  : public TTProcmapPolicy<Key>, TTPriomapPolicy<Key>, TTInlinePolicy<Key>
+  { };
+
+  namespace detail {
+    template<typename MapT>
+    struct is_default_keymap : std::false_type
+    { };
+
+    template<typename Key>
+    struct is_default_keymap<ttg::meta::detail::keymap<Key>> : std::true_type
+    { };
+
+    template<typename T>
+    constexpr const bool is_default_keymap_v = is_default_keymap<T>::value;
+
+    template<typename MapT>
+    struct map_type {
+      using type = MapT;
+    };
+
+    template<typename Key>
+    struct map_type<ttg::meta::detail::keymap<Key>> {
+      using type = ttg::meta::detail::keymap_t<Key>;
+    };
+
+    template<typename T>
+    using map_type_t = typename map_type<T>::type;
+
+  } // namespace detail
+
+  /**
+   * \brief Base class for task execution policies.
+   *
+   * Policies are properties of tasks. Tasks are identified through the key.
+   * A policy implementation maps a key to an integer value and can be set per TT.
+   * Supported policies include:
+   *  * Process mapping: maps a key identifying a task to a process to run on.
+   *  * Priority mapping: assigns a priority (positive integer) to a task identified by a key.
+   *                      Higher values increase the task's priority.
+   *  * Inline mapping: whether a task can be executed inline, i.e., without dispatching the
+   *                    task to a scheduler first. The task will be executed in the send or
+   *                    broadcast call. The returned value denotes the maximum recirsion depth,
+   *                    i.e., how many tasks may be executed inline consecutively. Zero denotes
+   *                    no inlining. This is the default.
+   *
+   * The default mapping functions are not inlined and can be set dynamically
+   * in the TT. By inheriting from \c TTPolicyBase and passing callables to its
+   * constructor, applications can define policies at compile-time. This may
+   * yield improved performance since the compiler is potentially able to inline
+   * the calls. In that case, the dynamic setting of mapping functions in the
+   * TT will be disabled.
+   *
+   * \tparam Key The type of the key used to identify tasks.
+   * \tparam ProcMap The type of the process map callback.
+   * \tparam PrioMap The type of the priority map callback.
+   * \tparam InlineMap The type of the inline map callback.
+   *
+   * \sa ttg::make_policy
+   */
+  template<typename Key,
+           typename ProcMap = typename ttg::meta::detail::keymap<Key>,
+           typename PrioMap = typename ttg::meta::detail::keymap<Key>,
+           typename InlineMap = typename ttg::meta::detail::keymap<Key>>
+  struct TTPolicyBase {
+
+    using procmap_t = detail::map_type_t<ProcMap>;
+    using priomap_t = detail::map_type_t<PrioMap>;
+    using inlinemap_t = detail::map_type_t<InlineMap>;
+
+    procmap_t procmap;
+    priomap_t priomap;
+    inlinemap_t inlinemap;
+
+    static constexpr bool is_default_procmap = detail::is_default_keymap_v<ProcMap>;
+    static constexpr bool is_default_priomap = detail::is_default_keymap_v<PrioMap>;
+    static constexpr bool is_default_inlinemap = detail::is_default_keymap_v<InlineMap>;
+
+    template<typename ProcMap_ = ProcMap,
+             typename PrioMap_ = PrioMap,
+             typename InlineMap_ = InlineMap,
+             typename Enabler = std::enable_if_t<is_default_procmap &&
+                                                 is_default_priomap &&
+                                                 is_default_inlinemap>>
+    TTPolicyBase()
+    : TTPolicyBase(ttg::meta::detail::keymap_t<Key>(ttg::detail::default_keymap<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+    { }
+
+    template<typename ProcMap_,
+             typename PrioMap_ = PrioMap,
+             typename InlineMap_ = InlineMap,
+             typename Enabler = std::enable_if_t<is_default_priomap && is_default_inlinemap>>
+    TTPolicyBase(ProcMap_&& procmap)
+    : TTPolicyBase(std::forward<ProcMap_>(procmap),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_priomap<Key>()),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+    { }
+
+    template<typename ProcMap_,
+             typename PrioMap_,
+             typename InlineMap_ = InlineMap,
+             typename Enabler = std::enable_if_t<is_default_inlinemap>>
+    TTPolicyBase(ProcMap_&& procmap, PrioMap_&& priomap)
+    : TTPolicyBase(std::forward<ProcMap_>(procmap),
+                   std::forward<PrioMap_>(priomap),
+                   ttg::meta::detail::keymap_t<Key>(ttg::detail::default_inlinemap<Key>()))
+    { }
+
+    template<typename ProcMap_, typename PrioMap_, typename InlineMap_>
+    TTPolicyBase(ProcMap_&& procmap,
+                 PrioMap_&& priomap,
+                 InlineMap_&& im)
+    : procmap(std::forward<ProcMap_>(procmap)),
+      priomap(std::forward<PrioMap_>(priomap)),
+      inlinemap(std::forward<InlineMap_>(im))
+    { }
+
+    /**
+     * Rebind the default process map to the provided world, if the process map
+     * is the default map.
+     */
+    inline
+    void rebind(ttg::World& world) {
+      if constexpr (is_default_procmap) {
+        procmap = ttg::detail::default_keymap<Key>(world);
+      }
+    }
+
+    const auto& get_procmap() const {
+      return procmap;
+    }
+
+    const auto& get_priomap() const {
+      return priomap;
+    }
+
+    const auto& get_inlinemap() const {
+      return inlinemap;
+    }
+  };
+
+
+  namespace detail {
+    template<typename Key, typename ProcMap, typename PrioMap, typename InlineMap>
+    struct TTPolicyWrapper {
+      ProcMap procmap;
+      PrioMap priomap;
+      InlineMap inlinemap;
+
+      template<typename ProcMap_, typename PrioMap_, typename InlineMap_>
+      TTPolicyWrapper(ProcMap_&& procmap = ttg::detail::default_keymap<Key>(),
+                      PrioMap_&& priomap = ttg::detail::default_priomap<Key>(),
+                      InlineMap_&& im = ttg::detail::default_inlinemap<Key>())
+      : procmap(std::forward<ProcMap_>(procmap)),
+        priomap(std::forward<PrioMap_>(priomap)),
+        inlinemap(std::forward<InlineMap_>(im))
+      { }
+
+      auto get_procmap() {
+        return procmap;
+      }
+
+      auto get_priomap() {
+        return priomap;
+      }
+
+      auto get_inlinemap() {
+        return inlinemap;
+      }
+    };
+  } // namespace detail
+
+  /**
+   * Helper function to create a TT policy from arbitrary function objects.
+   * The order of callables is
+   *   1) Process map
+   *   2) Priority map
+   *   3) Inline map
+   *
+   * Example use:
+   *
+   * ttg::make_policy(
+   *   // Process map: round robin on field i of key
+   *   [&](const Key& key){ return key.i % world.size(); },
+   *   // Priority map: use key field p as priority
+   *   [&](const Key& key){ return key.p; },
+   *   // Inline map: never inline
+   *   [&](const Key& key){ return 0; });
+   *
+   * \sa TTPolicy
+   */
+  template<typename Key, typename ...Args>
+  auto make_policy(Args&& ...args)
+  {
+    return TTPolicyBase<Key, Args...>(std::forward<Args>(args)...);
+  }
+
+} // namespace ttg
+
+#endif // TTG_POLICIES_H

--- a/ttg/ttg/policies.h
+++ b/ttg/ttg/policies.h
@@ -35,15 +35,20 @@ namespace ttg {
 
     /* Some handy trait to check if a type is std::function<X(Y...)> */
     template<typename T>
-    struct is_std_function : std::false_type
+    struct is_std_function_ptr : std::false_type
+    { };
+
+    /** std::function member pointer */
+    template<typename T, typename Ret, typename... Args>
+    struct is_std_function_ptr<std::function<Ret(Args...)> T::*> : std::true_type
     { };
 
     template<typename Ret, typename... Args>
-    struct is_std_function<std::function<Ret(Args...)>> : std::true_type
+    struct is_std_function_ptr<std::function<Ret(Args...)>*> : std::true_type
     { };
 
     template<typename T>
-    constexpr bool is_std_function_v = is_std_function<T>::value;
+    constexpr bool is_std_function_ptr_v = is_std_function_ptr<T>::value;
 
   } // namespace detail
 
@@ -153,15 +158,9 @@ namespace ttg {
       ttg::detail::default_priomap_impl<Key> m_default_priomap;
       ttg::detail::default_inlinemap_impl<Key> m_default_inlinemap;
 
-
-      static constexpr bool procmap_is_std_function = !std::is_member_function_pointer_v<decltype(&TTPolicyImpl::procmap)>
-                                                    && detail::is_std_function_v<decltype(TTPolicyImpl::procmap)>;
-
-      static constexpr bool priomap_is_std_function = !std::is_member_function_pointer_v<decltype(&TTPolicyImpl::priomap)>
-                                                    && detail::is_std_function_v<decltype(TTPolicyImpl::priomap)>;
-
-      static constexpr bool inlinemap_is_std_function = !std::is_member_function_pointer_v<decltype(&TTPolicyImpl::inlinemap)>
-                                                      && detail::is_std_function_v<decltype(TTPolicyImpl::inlinemap)>;
+      static constexpr bool procmap_is_std_function = detail::is_std_function_ptr_v<decltype(&TTPolicyImpl::procmap)>;
+      static constexpr bool priomap_is_std_function = detail::is_std_function_ptr_v<decltype(&TTPolicyImpl::priomap)>;
+      static constexpr bool inlinemap_is_std_function = detail::is_std_function_ptr_v<decltype(&TTPolicyImpl::inlinemap)>;
 
     public:
 
@@ -328,13 +327,9 @@ namespace ttg {
 
       template<typename ProcMap>
       void set_procmap(ProcMap&& pm) {
-        if constexpr (std::is_member_function_pointer_v<decltype(&TTPolicyImpl::procmap)> ||
-                      !std::is_assignable_v<decltype(TTPolicyImpl::procmap), ProcMap>) {
-          static_assert(std::is_assignable_v<decltype(TTPolicyImpl::procmap), ProcMap>,
-                        "Cannot set process map on compile-time policy property!");
-        } else {
-          m_policy.procmap = std::forward<ProcMap>(pm);
-        }
+        static_assert(std::is_assignable_v<decltype(TTPolicyImpl::procmap), ProcMap>,
+                      "Cannot set process map on compile-time policy property!");
+        m_policy.procmap = std::forward<ProcMap>(pm);
       }
 
       template<typename KeyMap>
@@ -344,28 +339,19 @@ namespace ttg {
 
       template<typename PrioMap>
       void set_priomap(PrioMap&& pm) {
-        if constexpr (std::is_member_function_pointer_v<decltype(&TTPolicyImpl::priomap)> ||
-                      !std::is_assignable_v<decltype(TTPolicyImpl::priomap), PrioMap>) {
-          static_assert(std::is_assignable_v<decltype(TTPolicyImpl::priomap), PrioMap>,
-                        "Cannot set process map on compile-time policy property!");
-        } else {
-          m_policy.priomap = std::forward<PrioMap>(pm);
-        }
+        static_assert(std::is_assignable_v<decltype(TTPolicyImpl::priomap), PrioMap>,
+                      "Cannot set process map on compile-time policy property!");
+        m_policy.priomap = std::forward<PrioMap>(pm);
       }
 
       template<typename InlineMap>
       void set_inlinemap(InlineMap&& pm) {
-        if constexpr (std::is_member_function_pointer_v<decltype(&TTPolicyImpl::inlinemap)> ||
-                      !std::is_assignable_v<decltype(TTPolicyImpl::inlinemap), InlineMap>) {
-          static_assert(std::is_assignable_v<decltype(TTPolicyImpl::inlinemap), InlineMap>,
-                        "Cannot set process map on compile-time policy property!");
-        } else {
-          m_policy.inlinemap = std::forward<InlineMap>(pm);
-        }
+        static_assert(std::is_assignable_v<decltype(TTPolicyImpl::inlinemap), InlineMap>,
+                      "Cannot set process map on compile-time policy property!");
+        m_policy.inlinemap = std::forward<InlineMap>(pm);
       }
 
     };
-
   } // namespace detail
 
   /**

--- a/ttg/ttg/reduce.h
+++ b/ttg/ttg/reduce.h
@@ -28,10 +28,9 @@ namespace ttg {
   template <typename Value, typename BinaryOp, typename OutKey>
   class BinaryTreeReduce
       : public TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                  BinaryTreeReduce<Value, BinaryOp, OutKey>, Value, Value, Value> {
+                  BinaryTreeReduce<Value, BinaryOp, OutKey>, ttg::typelist<Value, Value, Value>> {
    public:
-    using baseT = TT<int, std::tuple<Out<int, Value>, Out<int, Value>, Out<int, Value>, Out<OutKey, Value>>,
-                     BinaryTreeReduce<Value, BinaryOp, OutKey>, Value, Value, Value>;
+    using baseT = typename BinaryTreeReduce::ttT;
 
     BinaryTreeReduce(Edge<int, Value> &in, Edge<OutKey, Value> &out, int root = 0, OutKey dest_key = OutKey(),
                      BinaryOp op = BinaryOp{}, World world = ttg::default_execution_context(), int max_key = -1,

--- a/ttg/ttg/reduce.h
+++ b/ttg/ttg/reduce.h
@@ -93,7 +93,7 @@ namespace ttg {
       // iterate over keys that map to me ... if keys are equivalent to ranks this can be made simpler
       const auto my_rank = this->get_world().rank();
       for (auto key = 0; key != tree_.size(); ++key) {
-        if (my_rank == this->get_policy().procmap(key)) {
+        if (my_rank == this->procmap(key)) {
           auto keys = tree_.child_keys(key);
           if (keys.first == -1) this->template set_arg<1>(key, Value());
           if (keys.second == -1) this->template set_arg<2>(key, Value());

--- a/ttg/ttg/reduce.h
+++ b/ttg/ttg/reduce.h
@@ -10,6 +10,7 @@
 #include <mutex>
 
 #include "ttg/util/tree.h"
+#include "ttg/policies.h"
 
 namespace ttg {
 
@@ -37,7 +38,8 @@ namespace ttg {
                      Edge<int, Value> inout = Edge<int, Value>{}, Edge<int, Value> inout_l = Edge<int, Value>{},
                      Edge<int, Value> inout_r = Edge<int, Value>{})
         : baseT(edges(fuse(in, inout), inout_l, inout_r), edges(inout, inout_l, inout_r, out), "BinaryTreeReduce",
-                {"in|inout", "inout_l", "inout_r"}, {"inout", "inout_l", "inout_r", "out"}, world, [](int key) { return key; })
+                {"in|inout", "inout_l", "inout_r"}, {"inout", "inout_l", "inout_r", "out"}, world,
+                ttg::TTPolicyBase<int>([](int key) { return key; }))
         , tree_((max_key == -1 ? world.size() : max_key), root)
         , dest_key_(dest_key)
         , op_(std::move(op)) {
@@ -91,7 +93,7 @@ namespace ttg {
       // iterate over keys that map to me ... if keys are equivalent to ranks this can be made simpler
       const auto my_rank = this->get_world().rank();
       for (auto key = 0; key != tree_.size(); ++key) {
-        if (my_rank == this->get_keymap()(key)) {
+        if (my_rank == this->get_policy().procmap(key)) {
           auto keys = tree_.child_keys(key);
           if (keys.first == -1) this->template set_arg<1>(key, Value());
           if (keys.second == -1) this->template set_arg<2>(key, Value());

--- a/ttg/ttg/terminal.h
+++ b/ttg/ttg/terminal.h
@@ -178,6 +178,21 @@ namespace ttg {
     }
   };
 
+  namespace detail {
+    template<typename keyT, typename... valuesT>
+    struct input_terminals_tuple {
+      using type = std::tuple<ttg::In<keyT, valuesT>...>;
+    };
+
+    template<typename keyT, typename... valuesT>
+    struct input_terminals_tuple<keyT, std::tuple<valuesT...>> {
+      using type = std::tuple<ttg::In<keyT, valuesT>...>;
+    };
+
+    template<typename keyT, typename... valuesT>
+    using input_terminals_tuple_t = typename input_terminals_tuple<keyT, valuesT...>::type;
+  } // namespace detail
+
   // Output terminal
   template <typename keyT = void, typename valueT = void>
   class Out : public TerminalBase {

--- a/ttg/ttg/util/typelist.h
+++ b/ttg/ttg/util/typelist.h
@@ -1,0 +1,39 @@
+#ifndef TTG_UTIL_INPUTTYPES_H
+#define TTG_UTIL_INPUTTYPES_H
+
+#include <tuple>
+
+namespace ttg {
+
+  /**
+   * \brief A container for types.
+   *
+   * We use this to work around ADL issues when templating ttg::TT with
+   * std::tuple. This is a simple wrapper type holding type information.
+   * A tuple containing the types can be extracted using the \c tuple_type
+   * member type.
+   */
+  template<typename... Ts>
+  struct typelist
+  {
+    using tuple_type = std::tuple<Ts...>;
+  };
+
+  namespace detail {
+
+    template<typename T>
+    struct is_typelist : std::false_type
+    { };
+
+    template<typename... Ts>
+    struct is_typelist<ttg::typelist<Ts...>> : std::true_type
+    { };
+
+    template<typename T>
+    constexpr bool is_typelist_v = is_typelist<T>::value;
+
+  } // namespace detail
+
+} // namespace ttg
+
+#endif // TTG_UTIL_INPUTTYPES_H


### PR DESCRIPTION
Policies are a mechanism to steer the execution of tasks through a single entity controlling different properties. The interface is extensible to allow for the addition of future properties without breaking backwards compatibility. If desired, providing a custom policy allows the compiler to fully inline all calls and thus avoid a bunch of indirect calls through `std::function`. This is useful for small tasks and allows us to reduce the overhead of querying these properties.

Currently, three properties are supported:

1) Process map (aka keymap): map a key identifying a task to a process for execution. Implemented using the `int procmap(const Key&)` member.
2) Priority map: map a key identifying a task to a priority. Implemented using the `int priomap(const Key&)` member.
3) Inline map: map a key identifying a task to a max depth for inlining. Implemented using the `int inlinemap(const Key&)` member. This has yet to be implemented in the backends.

Policies can be specified in two ways:

1) Using `make_policy()` to work with `make_tt`. Example:
```C
return ttg::make_tt([](){ /* task function */ }, edges(...), edges(...), 
                ttg::make_policy([](const Key& key){ return key % world.size(); }, 
                                 [](const Key& key){ return key.x; /* priority */}));
```
Functions are defaulted to make sure that all necessary properties are implemented. A function that is not provided can later be set dynamically on the tt (using `tt->set_inlinemap([](const Key&){ return 0; })` in the example above).

2) Using a custom policy class:

```C
struct MyPolicy : public ttg::TTPolicyBase {
  ttg::World world;
  MyPolicy(ttg::World world)
  : world(world), TTPolicyBase()
  { }
  int procmap(const Key& key) {
    return key % world.size();
  }
};

struct MyTT : ttg::TT<..., MyPolicy>
{
  ...
}
```
The `procmap` member function will shadow the `procmap` member of `ttg::TTPolicyBase`. Since the TT is templated on the policy, the `procmap` of `MyPolicy` is used. There is no need for virtual functions here. Similarly to the above, properties not specified in `MyPolicy` are defaulted to a `std::function` and can be set dynamically.

This PR is based on #217 to be able to default the policy type of TT so the diff is bigger than it will be if #217 gets merged.