### PR TITLE
HOTFIX: make_tt without explicit out parameter does not manage well inline/recursive calling of function

### DIFF
--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -129,6 +129,7 @@ namespace ttg {
       return outputs_tls_ptr;
     }
     void set_outputs_tls_ptr() { outputs_tls_ptr_accessor() = &this->outputs; }
+    void set_outputs_tls_ptr(const std::vector<TerminalBase *> *ptr) { outputs_tls_ptr_accessor() = ptr; }
 
    public:
     virtual ~TTBase() = default;

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -29,8 +29,10 @@ class CallableWrapTT
     if constexpr (funcT_receives_outterm_tuple)
       func(std::forward<Key>(key), std::forward<Tuple>(args), out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(std::forward<Key>(key), std::forward<Tuple>(args));
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -39,8 +41,10 @@ class CallableWrapTT
     if constexpr (funcT_receives_outterm_tuple)
       func(std::forward<TupleOrKey>(args), out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(std::forward<TupleOrKey>(args));
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -48,8 +52,10 @@ class CallableWrapTT
     if constexpr (funcT_receives_outterm_tuple)
       func(std::tuple<>(), out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(std::tuple<>());
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -142,9 +148,11 @@ class CallableWrapTTArgs
       func(std::forward<Key>(key),
            baseT::template get<S, std::tuple_element_t<S + 1, func_args_t>>(std::forward<Tuple>(args_tuple))..., out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(std::forward<Key>(key),
            baseT::template get<S, std::tuple_element_t<S + 1, func_args_t>>(std::forward<Tuple>(args_tuple))...);
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -154,8 +162,10 @@ class CallableWrapTTArgs
     if constexpr (funcT_receives_outterm_tuple)
       func(baseT::template get<S, std::tuple_element_t<S, func_args_t>>(std::forward<Tuple>(args_tuple))..., out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(baseT::template get<S, std::tuple_element_t<S, func_args_t>>(std::forward<Tuple>(args_tuple))...);
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -164,8 +174,10 @@ class CallableWrapTTArgs
     if constexpr (funcT_receives_outterm_tuple)
       func(std::forward<Key>(key), out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func(std::forward<Key>(key));
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 
@@ -174,8 +186,10 @@ class CallableWrapTTArgs
     if constexpr (funcT_receives_outterm_tuple)
       func(out);
     else {
+      auto old_output_tls_ptr = this->outputs_tls_ptr_accessor();
       this->set_outputs_tls_ptr();
       func();
+      this->set_outputs_tls_ptr(old_output_tls_ptr);
     }
   }
 


### PR DESCRIPTION
Some backends (MADNESS) allow to recursively call the function during… the call to send, this the TLS for the outputs need to be stored and restored before/after the function call, or we may work with the wrong outputs