### PR TITLE
Adapt the github workflow to run on nektos/act

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,11 +38,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{github.workspace}}/build
-
     - name: Install prerequisite MacOS packages
       if: ${{ matrix.os == 'macos-latest' }}
       run: brew install ninja gcc@10 boost eigen open-mpi bison ccache
@@ -50,10 +45,23 @@ jobs:
     - name: Install prerequisites Ubuntu packages
       if: ${{ matrix.os == 'ubuntu-20.04' }}
       run: |
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+        sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
         sudo apt-get update
-        sudo apt-get install ninja-build g++-9 liblapack-dev libboost-dev libboost-serialization-dev libeigen3-dev openmpi-bin libopenmpi-dev libtbb-dev ccache
+        sudo apt-get -y install ninja-build g++-9 liblapack-dev libboost-dev libboost-serialization-dev libeigen3-dev openmpi-bin libopenmpi-dev libtbb-dev ccache flex bison cmake
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: |
+        cmake -E make_directory ${{github.workspace}}/build
+
+
+    - name: Install doxygen for Release test
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      run: |
         if [ "${{matrix.build_type}}" = "Release" ]; then
-          sudo apt-get install libclang1-9 libclang-cpp9 graphviz fonts-liberation
+          sudo apt-get -y install libclang1-9 libclang-cpp9 graphviz fonts-liberation
           cd ${{github.workspace}}/build
           # wget https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           # using EFV's gdrive mirror of 1.9.2 to work around the unreliable sourceforge

--- a/tests/unit/unit_main.cpp
+++ b/tests/unit/unit_main.cpp
@@ -14,15 +14,12 @@ int main(int argc, char** argv) {
   Catch::Session session;
 
   // global setup...
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::cout.precision(std::numeric_limits<double>::max_digits10);
   std::cerr.precision(std::numeric_limits<double>::max_digits10);
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
   std::wcout.sync_with_stdio(false);
   std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
   std::wcout.sync_with_stdio(true);
   std::wcerr.sync_with_stdio(true);
 


### PR DESCRIPTION
See https://github.com/nektos/act

Not sure we want to merge it. I'm still seeing the following errors for the unittests:

```
| 25: terminate called after throwing an instance of 'std::runtime_error'
| 25:   what():  locale::facet::_S_create_c_locale name not valid
```

That only occurs on the core-unittests though, all other tests succeed on my machine.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>