### PR TITLE
Github: set OMPI and PaRSEC related env variables and remove setlocale

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,6 +26,8 @@ jobs:
       CCACHE_DIR : ${{github.workspace}}/build/.ccache
       CCACHE_COMPRESS : true
       CCACHE_COMPRESSLEVEL : 6
+      OMPI_MCA_btl_vader_single_copy_mechanism : none
+      PARSEC_MCA_runtime_bind_threads : 0
       BUILD_CONFIG : >
         -G Ninja
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}


### PR DESCRIPTION
`OMPI_MCA_btl_vader_single_copy_mechanism` is meant to suppress an error message from an incompatibility between btl/vader and docker, see https://github.com/open-mpi/ompi/issues/4948.

`PARSEC_MCA_runtime_bind_threads` is meant to disable thread binding in PaRSEC, potentially speeding up test runs.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>