### PR TITLE
Cast keys passed to invoke() to known key types

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -3075,11 +3075,16 @@ namespace ttg_parsec {
     std::enable_if_t<!ttg::meta::is_void_v<Key> && !ttg::meta::is_empty_tuple_v<input_values_tuple_type>, void> invoke(
         const Key &key, const input_values_tuple_type &args) {
       TTG_OP_ASSERT_EXECUTABLE();
-      /* trigger non-void inputs */
-      set_args(ttg::meta::nonvoid_index_seq<actual_input_tuple_type>{}, key, args);
-      /* trigger void inputs */
-      using void_index_seq = ttg::meta::void_index_seq<actual_input_tuple_type>;
-      set_args(void_index_seq{}, key, ttg::detail::make_void_tuple<void_index_seq::size()>());
+      if constexpr(!std::is_same_v<Key, key_type>) {
+        key_type k = key; /* cast that type into the key type we know */
+        invoke(k, args);
+      } else {
+        /* trigger non-void inputs */
+        set_args(ttg::meta::nonvoid_index_seq<actual_input_tuple_type>{}, key, args);
+        /* trigger void inputs */
+        using void_index_seq = ttg::meta::void_index_seq<actual_input_tuple_type>;
+        set_args(void_index_seq{}, key, ttg::detail::make_void_tuple<void_index_seq::size()>());
+      }
     }
 
     // Manual injection of a key-free task and all input arguments specified as a tuple
@@ -3099,9 +3104,15 @@ namespace ttg_parsec {
     std::enable_if_t<!ttg::meta::is_void_v<Key> && ttg::meta::is_empty_tuple_v<input_values_tuple_type>, void> invoke(
         const Key &key) {
       TTG_OP_ASSERT_EXECUTABLE();
-      /* trigger void inputs */
-      using void_index_seq = ttg::meta::void_index_seq<actual_input_tuple_type>;
-      set_args(void_index_seq{}, key, ttg::detail::make_void_tuple<void_index_seq::size()>());
+
+      if constexpr(!std::is_same_v<Key, key_type>) {
+        key_type k = key; /* cast that type into the key type we know */
+        invoke(k);
+      } else {
+        /* trigger void inputs */
+        using void_index_seq = ttg::meta::void_index_seq<actual_input_tuple_type>;
+        set_args(void_index_seq{}, key, ttg::detail::make_void_tuple<void_index_seq::size()>());
+      }
     }
 
     // Manual injection of a task that has no key or arguments


### PR DESCRIPTION
Otherwise the user controls the key type sent in messages to remote owners of tasks.