### PR TITLE
Synchronize on make_graph_executable

### DIFF
--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -20,6 +20,8 @@ namespace ttg_madness {
 
   class WorldImpl;
 
+  inline void make_executable_hook(ttg::World&);
+
   inline void ttg_initialize(int argc, char **argv, int num_threads = -1);
 
   inline void ttg_finalize();

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -116,6 +116,8 @@ namespace ttg_madness {
 #endif
   };
 
+  inline void make_executable_hook(ttg::World& world) { }
+
   inline void ttg_initialize(int argc, char **argv, int num_threads) {
     if (num_threads < 1) num_threads = ttg::detail::num_threads();
     ::madness::World &madworld = ::madness::initialize(argc, argv, num_threads, /* quiet = */ true);

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -22,6 +22,8 @@ namespace ttg_parsec {
 
   class WorldImpl;
 
+  inline void make_executable_hook(ttg::World&);
+
   inline void ttg_initialize(int argc, char **argv, int num_threads = -1, parsec_context_s * = nullptr);
 
   inline void ttg_finalize();

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -469,7 +469,7 @@ namespace ttg_parsec {
 #endif
   };
 
-  static void unregister_parsec_tags(void *_)
+  inline void unregister_parsec_tags(void *_)
   {
     if(NULL != parsec_ce.tag_unregister) {
       parsec_ce.tag_unregister(WorldImpl::parsec_ttg_tag());
@@ -1033,6 +1033,10 @@ namespace ttg_parsec {
     double result = 0.0;
     MPI_Allreduce(&value, &result, 1, MPI_DOUBLE, MPI_SUM, world.impl().comm());
     value = result;
+  }
+
+  inline void make_executable_hook(ttg::World& world) {
+    MPI_Barrier(world.impl().comm());
   }
 
   /// broadcast


### PR DESCRIPTION
PaRSEC needs to make sure that no AMs are delivered before the callbacks are registered, which happens in make_graph_executable. So we add a hook that becomes a barrier for PaRSEC and is empty for madness.

@Ashawini27 this should fix your hangs. Please give it a try and let me know if not :)