### PR TITLE
RFC: more verbose, more readable TT construction

### DIFF
--- a/tests/unit/tt.cc
+++ b/tests/unit/tt.cc
@@ -437,4 +437,23 @@ TEST_CASE("TemplateTask", "[core]") {
       static_assert(!ttg::meta::is_generic_callable_v<decltype(&args_pmf::X::g<int>)>);
     }
   }
+
+//#if 0
+  SECTION("split_construction") {
+    ttg::Edge<int, float> a2b, b2a;
+    /* construct without edges */
+    auto tta = ttg::make_tt([](int key, float value){});
+    tta->set_input<0>(b2a)
+       .set_output<0>(a2b)
+       .set_name("A");
+
+    auto ttb = ttg::make_tt([](int key, float value){});
+    ttb->set_input<0>(a2b)
+       .set_output<0>(b2a)
+       .set_name("B");
+
+    bool is_executable = ttg::make_graph_executable(tta);
+    CHECK(is_executable);
+  }
+//#endif // 0
 }

--- a/ttg/ttg/base/terminal.h
+++ b/ttg/ttg/base/terminal.h
@@ -88,6 +88,11 @@ namespace ttg {
       return name;
     }
 
+    TerminalBase& set_name(const std::string& name) {
+      this->name = name;
+      return *this;
+    }
+
     /// Returns string representation of key type
     const std::string &get_key_type_str() const {
       if (!tt) throw "ttg::TerminalBase:get_key_type_str() but tt is null";

--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -60,6 +60,13 @@ namespace ttg {
       outputs[i] = t;
     }
 
+    void set_output_dynamic(size_t i, TerminalBase *t) {
+      if (i >= outputs.size()) {
+        outputs.resize(i+1);
+      }
+      outputs[i] = t;
+    }
+
     template <bool out, typename terminalT, std::size_t i, typename setfuncT>
     void register_terminal(terminalT &term, const std::string &name, const setfuncT setfunc) {
       term.set(this, i, name, detail::demangled_type_name<typename terminalT::key_type>(),
@@ -211,7 +218,10 @@ namespace ttg {
     }
 
     /// Sets the name of this operation
-    void set_name(const std::string &name) { this->name = name; }
+    TTBase& set_name(const std::string &name) {
+      this->name = name;
+      return *this;
+    }
 
     /// Gets the name of this operation
     const std::string &get_name() const { return name; }

--- a/ttg/ttg/util/meta/callable.h
+++ b/ttg/ttg/util/meta/callable.h
@@ -58,7 +58,7 @@ namespace ttg::meta {
   }
 
   template <std::size_t Ordinal, typename Func, typename... Typelists, std::size_t... ArgIdx>
-  auto compute_arg_binding_types_impl(Func& func, typelist<Typelists...> argument_type_lists,
+  auto compute_arg_binding_types_impl(Func&& func, typelist<Typelists...> argument_type_lists,
                                       std::index_sequence<ArgIdx...> arg_idx = {}) {
     using arg_typelists_t = typelist<Typelists...>;
     constexpr auto Order = sizeof...(Typelists);
@@ -80,7 +80,7 @@ namespace ttg::meta {
   }
 
   template <std::size_t Ordinal, typename ReturnType, typename Func, typename... Typelists, std::size_t... ArgIdx>
-  auto compute_arg_binding_types_r_impl(Func& func, typelist<Typelists...> argument_type_lists,
+  auto compute_arg_binding_types_r_impl(Func&& func, typelist<Typelists...> argument_type_lists,
                                         std::index_sequence<ArgIdx...> arg_idx = {}) {
     using arg_typelists_t = typelist<Typelists...>;
     constexpr auto Order = sizeof...(Typelists);
@@ -110,7 +110,7 @@ namespace ttg::meta {
   ///         - the first invocable combination of argument types discovered by row-major iteration, if @p func is a
   ///         generic callable
   template <typename Func, typename... Typelists>
-  auto compute_arg_binding_types(Func& func, typelist<Typelists...> argument_type_lists) {
+  auto compute_arg_binding_types(Func&& func, typelist<Typelists...> argument_type_lists) {
     constexpr auto is_generic__args = callable_args<Func&>;
     constexpr bool is_generic = is_generic__args.first;
     if constexpr (is_generic) {
@@ -131,7 +131,7 @@ namespace ttg::meta {
   ///         - the first invocable combination of argument types discovered by row-major iteration, if @p func is a
   ///         generic callable
   template <typename ReturnType, typename Func, typename... Typelists>
-  auto compute_arg_binding_types_r(Func& func, typelist<Typelists...> argument_type_lists) {
+  auto compute_arg_binding_types_r(Func&& func, typelist<Typelists...> argument_type_lists) {
     constexpr auto is_generic__args = callable_args<Func&>;
     constexpr bool is_generic = is_generic__args.first;
     if constexpr (is_generic) {


### PR DESCRIPTION
Based on a discussion between @bosilca, @therault and myself, I started to extend the API to improve readability. This gets us a bit closer to the style of TaskFlow.
Example:

The old way:

```
    ttg::Edge<int, float> a2b, b2a;
    /* construct without edges */
    auto tta = ttg::make_tt([](int key, float value){}, ttg::edges(a2b), ttg::edges(b2a), 
                            "A", {"b2a"}, {"a2b"});
```

The new way:

```
    ttg::Edge<int, float> a2b, b2a;
    /* construct without edges */
    auto tta = ttg::make_tt([](int key, float value){ ... });
    tta->set_input<0>(b2a, "b2a")
       .set_output<0>(a2b, "a2b")
       .set_name("A");

    auto ttb = ttg::make_tt([](int key, float value){ ... });
    ttb->set_input<0>(a2b, "a2b")
       .set_output<0>(b2a, "b2a")
       .set_name("B");
```

This patch preserves the old way and adds the partial construction. The named member functions provide context for the arguments and help structure the code, at the cost of being more verbose.

Notes:

1) We cannot support generic functors (i.e., all arguments have to be explicitly typed)
2) We select the first functor argument as the key. If there are no functor arguments or key is void it has to be specified explicitly as first template argument to `make_tt`.
3) Input edges are still type checked based on the argument types. Output edges can be type-checked if the functor takes the output terminal tuple (not implemented yet). Otherwise type checking is done in debug builds via dynamic casts.
3) Not yet implemented for MADNESS. Just wanted to put out a PoC for discussion.