### PR TITLE
Boost serialization: avoid virtual function calls

### DIFF
--- a/tests/unit/serialization.cc
+++ b/tests/unit/serialization.cc
@@ -504,7 +504,7 @@ TEST_CASE("MADNESS Serialization", "[serialization]") {
 
     T g_obj;
     void* g = (void*)&g_obj;
-    CHECK_NOTHROW(d->unpack_payload(g, obj_size, 0, buf.get()));
+    CHECK(d->unpack_payload(g, obj_size, 0, buf.get()) == pos);
   };
 
   test(99);
@@ -755,7 +755,7 @@ TEST_CASE("TTG Serialization", "[serialization]") {
 
     T g_obj;
     void* g = (void*)&g_obj;
-    CHECK_NOTHROW(d->unpack_payload(g, obj_size, 0, buf.get()));
+    CHECK(d->unpack_payload(g, obj_size, 0, buf.get()) == pos);
   };
 
   test(99);

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1835,13 +1835,12 @@ ttg::abort();  // should not happen
       uint64_t payload_size;
       if constexpr (!ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>::serialize_size_is_const) {
         const ttg_data_descriptor *dSiz = ttg::get_data_descriptor<uint64_t>();
-        dSiz->unpack_payload(&payload_size, sizeof(uint64_t), pos, _bytes);
-        pos += sizeof(uint64_t);
+        pos = dSiz->unpack_payload(&payload_size, sizeof(uint64_t), pos, _bytes);
       } else {
         payload_size = dObj->payload_size(&obj);
       }
-      dObj->unpack_payload(&obj, payload_size, pos, _bytes);
-      return pos + payload_size;
+      pos = dObj->unpack_payload(&obj, payload_size, pos, _bytes);
+      return pos;
     }
 
     template <typename T>
@@ -1855,11 +1854,10 @@ ttg::abort();  // should not happen
 
       if constexpr (!ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>::serialize_size_is_const) {
         const ttg_data_descriptor *dSiz = ttg::get_data_descriptor<uint64_t>();
-        dSiz->pack_payload(&payload_size, sizeof(uint64_t), pos, bytes);
-        pos += sizeof(uint64_t);
+        pos = dSiz->pack_payload(&payload_size, sizeof(uint64_t), pos, bytes);
       }
-      dObj->pack_payload(&obj, payload_size, pos, bytes);
-      return pos + payload_size;
+      pos = dObj->pack_payload(&obj, payload_size, pos, bytes);
+      return pos;
     }
 
     static void static_set_arg(void *data, std::size_t size, ttg::TTBase *bop) {

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1831,32 +1831,30 @@ ttg::abort();  // should not happen
    protected:
     template <typename T>
     uint64_t unpack(T &obj, void *_bytes, uint64_t pos) {
-      const ttg_data_descriptor *dObj = ttg::get_data_descriptor<ttg::meta::remove_cvr_t<T>>();
+      using dd_t = ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>;
       uint64_t payload_size;
-      if constexpr (!ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>::serialize_size_is_const) {
-        const ttg_data_descriptor *dSiz = ttg::get_data_descriptor<uint64_t>();
-        pos = dSiz->unpack_payload(&payload_size, sizeof(uint64_t), pos, _bytes);
+      if constexpr (!dd_t::serialize_size_is_const) {
+        pos = ttg::default_data_descriptor<uint64_t>::unpack_payload(&payload_size, sizeof(uint64_t), pos, _bytes);
       } else {
-        payload_size = dObj->payload_size(&obj);
+        payload_size = dd_t::payload_size(&obj);
       }
-      pos = dObj->unpack_payload(&obj, payload_size, pos, _bytes);
+      pos = dd_t::unpack_payload(&obj, payload_size, pos, _bytes);
       return pos;
     }
 
     template <typename T>
     uint64_t pack(T &obj, void *bytes, uint64_t pos, detail::ttg_data_copy_t *copy = nullptr) {
-      const ttg_data_descriptor *dObj = ttg::get_data_descriptor<ttg::meta::remove_cvr_t<T>>();
-      uint64_t payload_size = dObj->payload_size(&obj);
+      using dd_t = ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>;
+      uint64_t payload_size = dd_t::payload_size(&obj);
       if (copy) {
         /* reset any tracked data, we don't care about the packing from the payload size */
         copy->iovec_reset();
       }
 
-      if constexpr (!ttg::default_data_descriptor<ttg::meta::remove_cvr_t<T>>::serialize_size_is_const) {
-        const ttg_data_descriptor *dSiz = ttg::get_data_descriptor<uint64_t>();
-        pos = dSiz->pack_payload(&payload_size, sizeof(uint64_t), pos, bytes);
+      if constexpr (!dd_t::serialize_size_is_const) {
+        pos = ttg::default_data_descriptor<uint64_t>::pack_payload(&payload_size, sizeof(uint64_t), pos, bytes);
       }
-      pos = dObj->pack_payload(&obj, payload_size, pos, bytes);
+      pos = dd_t::pack_payload(&obj, payload_size, pos, bytes);
       return pos;
     }
 

--- a/ttg/ttg/serialization/backends/boost/archive.h
+++ b/ttg/ttg/serialization/backends/boost/archive.h
@@ -219,6 +219,9 @@ namespace ttg::detail {
   using boost_buffer_oarchive =
       boost_optimized_oarchive<boost::iostreams::stream<boost::iostreams::basic_array_sink<char>>>;
 
+  /// an archive that constructs serialized representation of an object in a memory buffer, in an optimized manner
+  using boost_byte_oarchive = boost_optimized_oarchive<byte_ostreambuf>;
+
   /// constructs a boost_buffer_oarchive object
 
   /// @param[in] buf pointer to a memory buffer to which serialized representation will be written
@@ -316,6 +319,9 @@ namespace ttg::detail {
   using boost_buffer_iarchive =
       boost_optimized_iarchive<boost::iostreams::stream<boost::iostreams::basic_array_source<char>>>;
 
+  /// the deserializer for boost_byte_oarchive
+  using boost_byte_iarchive = boost_optimized_iarchive<byte_istreambuf>;
+
   /// constructs a boost_buffer_iarchive object
 
   /// @param[in] buf pointer to a memory buffer from which serialized representation will be read
@@ -359,6 +365,10 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(ttg::detail::boost_iovec_iarchive);
 BOOST_SERIALIZATION_USE_ARRAY_OPTIMIZATION_FOR_THIS_AND_BASE(ttg::detail::boost_iovec_iarchive);
 BOOST_SERIALIZATION_REGISTER_ARCHIVE(ttg::detail::boost_buffer_iarchive);
 BOOST_SERIALIZATION_USE_ARRAY_OPTIMIZATION_FOR_THIS_AND_BASE(ttg::detail::boost_buffer_iarchive);
+BOOST_SERIALIZATION_REGISTER_ARCHIVE(ttg::detail::boost_byte_oarchive);
+BOOST_SERIALIZATION_USE_ARRAY_OPTIMIZATION_FOR_THIS_AND_BASE(ttg::detail::boost_byte_oarchive);
+BOOST_SERIALIZATION_REGISTER_ARCHIVE(ttg::detail::boost_byte_iarchive);
+BOOST_SERIALIZATION_USE_ARRAY_OPTIMIZATION_FOR_THIS_AND_BASE(ttg::detail::boost_byte_iarchive);
 
 #undef BOOST_SERIALIZATION_USE_ARRAY_OPTIMIZATION_FOR_THIS_AND_BASE
 

--- a/ttg/ttg/serialization/backends/boost/archive.h
+++ b/ttg/ttg/serialization/backends/boost/archive.h
@@ -174,9 +174,7 @@ namespace ttg::detail {
         count = (count + sizeof(Elem) - 1) / sizeof(Elem);
         std::streamsize scount = static_cast<StreamOrStreambuf&>(this->pbase())
                                      .sputn(static_cast<const Elem*>(address), static_cast<std::streamsize>(count));
-        if (count != static_cast<std::size_t>(scount))
-          boost::serialization::throw_exception(
-              boost::archive::archive_exception(boost::archive::archive_exception::output_stream_error));
+        assert(count == static_cast<std::size_t>(scount));
       }
       else {  // ... else let boost::archive::basic_binary_oprimitive handle via std::stringbuf
               // (and associated virtual function calls ... no inlining for you)

--- a/ttg/ttg/serialization/backends/boost/archive.h
+++ b/ttg/ttg/serialization/backends/boost/archive.h
@@ -74,7 +74,19 @@ namespace ttg::detail {
 
   /// optimized data-only serializer
 
-  /// skips metadata (class version, etc.)
+  /// skips metadata (class version, etc.) by providing optimized save_override function that will be called by
+  /// `boost::archive::binary_oarchive_impl::save_override`
+  ///
+  /// \internal Using `boost::archive::binary_oarchive_impl` provides stock implementation for this custom archive. Unfortunately
+  /// `boost::archive::binary_oarchive_impl` uses the streambuf object via its std::streambuf base which means that
+  /// calls to `xsputn` are not inlined. To work around this problem, this class replaces several functions in
+  /// `boost::archive::binary_oarchive_impl` that were provided by `boost::archive::basic_binary_oprimitive`
+  /// such as `save`, `save_array` and `save_binary`; the latter calls the streambuf's sputn directly,
+  /// not via std::streambuf::sputn . To make sure these "replacements" are called this class must be used directly
+  /// rather than cast to `boost::archive::binary_oarchive_impl`, as an argument to
+  /// `oarchive_save_override_optimized_dispatch`
+  /// if \p StreamOrStreambuf is a streambuf (i.e. derived from std::streambuf).
+  ///
   template <typename StreamOrStreambuf>
   class boost_optimized_oarchive
       : private StreamOrStreambuf,
@@ -84,6 +96,8 @@ namespace ttg::detail {
     using pbase_type = StreamOrStreambuf;
     using base_type = boost::archive::binary_oarchive_impl<boost_optimized_oarchive<StreamOrStreambuf>,
                                                            std::ostream::char_type, std::ostream::traits_type>;
+    // if pbase_type is derived from std::streambuf can use this information to avoid virtual function calls and inline
+    static constexpr bool pbase_derived_from_stdstreambuf = std::is_base_of_v<std::streambuf, pbase_type>;
 
    private:
     friend class boost::archive::save_access;
@@ -108,9 +122,12 @@ namespace ttg::detail {
         : pbase_type(std::forward<Arg>(arg))
         , base_type(this->pbase(), boost::archive::no_header | boost::archive::no_codecvt){};
 
+    /// these provide optimized implementation that's called by base_type::save_override
+    /// @{
+
     template <class T>
     void save_override(const T& t) {
-      oarchive_save_override_optimized_dispatch(this->base(), t);
+        oarchive_save_override_optimized_dispatch(*this, t);
     }
 
     void save_override(const boost::archive::class_id_optional_type& /* t */) {}
@@ -121,11 +138,53 @@ namespace ttg::detail {
     void save_override(const boost::archive::class_id_type& t) {}
     void save_override(const boost::archive::class_id_reference_type& t) {}
 
+    /// @}
+
     void save_object(const void* x, const boost::archive::detail::basic_oserializer& bos) { abort(); }
 
+    /// override default implementations in base_type provided by basic_binary_oprimitive<Archive>
+    /// @{
+
+    // default saving of primitives.
+    template<class T>
+    void save(const T & t)
+    {
+      save_binary(& t, sizeof(T));
+    }
+
+    // trap usage of invalid uninitialized boolean which would
+    // otherwise crash on load.
+    void save(const bool t){
+      BOOST_ASSERT(0 == static_cast<int>(t) || 1 == static_cast<int>(t));
+      save_binary(& t, sizeof(t));
+    }
+
    public:
-    BOOST_ARCHIVE_DECL
-    void save_binary(const void* address, std::size_t count);
+
+    // the optimized save_array dispatches to save_binary
+    template <class ValueType>
+    void save_array(boost::serialization::array_wrapper<ValueType> const& a, unsigned int)
+    {
+      save_binary(a.address(),a.count()*sizeof(ValueType));
+    }
+
+    void save_binary(const void *address, std::size_t count) {
+      if constexpr (pbase_derived_from_stdstreambuf) {  // if we were given a streambuf use it directly ...
+        using Elem = std::ostream::char_type;
+        count = (count + sizeof(Elem) - 1) / sizeof(Elem);
+        std::streamsize scount = static_cast<StreamOrStreambuf&>(this->pbase())
+                                     .sputn(static_cast<const Elem*>(address), static_cast<std::streamsize>(count));
+        if (count != static_cast<std::size_t>(scount))
+          boost::serialization::throw_exception(
+              boost::archive::archive_exception(boost::archive::archive_exception::output_stream_error));
+      }
+      else {  // ... else let boost::archive::basic_binary_oprimitive handle via std::stringbuf
+              // (and associated virtual function calls ... no inlining for you)
+        this->base().save_binary(address, count);
+      }
+    }
+
+    /// @}
 
     template <class T>
     auto& operator<<(const T& t) {
@@ -139,7 +198,14 @@ namespace ttg::detail {
       return *this << t;
     }
 
-    const auto& streambuf() const { return this->pbase(); }
+    const auto& streambuf() const {
+      if constexpr (pbase_derived_from_stdstreambuf) {
+        return static_cast<const StreamOrStreambuf&>(this->pbase());
+      }
+      else {
+        return this->pbase();
+      }
+    }
     const auto& stream() const { return this->pbase(); }
   };
 

--- a/ttg/ttg/serialization/backends/boost/archive.h
+++ b/ttg/ttg/serialization/backends/boost/archive.h
@@ -230,8 +230,7 @@ namespace ttg::detail {
   /// @return a boost_buffer_oarchive object referring to @p buf
   inline auto make_boost_buffer_oarchive(void* const buf, std::size_t size, std::size_t buf_offset = 0) {
     assert(buf_offset <= size);
-    using arrsink_t = boost::iostreams::basic_array_sink<char>;
-    return boost_buffer_oarchive(arrsink_t(static_cast<char*>(buf) + buf_offset, size - buf_offset));
+    return ttg::detail::boost_byte_oarchive(ttg::detail::byte_ostreambuf(static_cast<char*>(buf) + buf_offset, size - buf_offset));
   }
 
   /// constructs a boost_buffer_oarchive object

--- a/ttg/ttg/serialization/stream.h
+++ b/ttg/ttg/serialization/stream.h
@@ -86,6 +86,11 @@ namespace ttg::detail {
       return n;
     }
 
+    /// number of characters written to the buffer
+    std::streamsize size() const noexcept {
+      return cursor_ - buffer_;
+    }
+
    private:
     char_type* buffer_;
     char_type* cursor_;  // current location in buffer_
@@ -109,6 +114,11 @@ namespace ttg::detail {
       std::memcpy(s, cursor_, n_to_read * sizeof(char_type));
       cursor_ += n_to_read;
       return n_to_read;
+    }
+
+    /// number of characters read from the buffer
+    std::streamsize size() const noexcept {
+      return cursor_ - buffer_;
     }
 
    private:

--- a/ttg/ttg/serialization/stream.h
+++ b/ttg/ttg/serialization/stream.h
@@ -72,9 +72,14 @@ namespace ttg::detail {
    public:
     using std::streambuf::streambuf;
 
-    byte_ostreambuf(char_type* buffer, std::streamsize buffer_size = std::numeric_limits<std::streamsize>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+    inline byte_ostreambuf(char_type* buffer, std::streamsize buffer_size = std::numeric_limits<std::streamsize>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
 
-    std::streamsize xsputn(const char_type* s, std::streamsize n) override {
+    // hides basic_streambuf::sputn so can avoid the virtual function dispatch if the compiler is not aggressive enough
+    inline std::streamsize sputn(const char_type* s, std::streamsize n) noexcept {
+      return this->xsputn(s, n);
+    }
+
+    inline std::streamsize xsputn(const char_type* s, std::streamsize n) noexcept override {
       assert((cursor_ - buffer_) + n <= buffer_size_);
       std::memcpy(cursor_, s, n * sizeof(char_type));
       cursor_ += n;
@@ -92,9 +97,14 @@ namespace ttg::detail {
    public:
     using std::streambuf::streambuf;
 
-    byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+    inline byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
 
-    std::streamsize xsgetn(char_type* s, std::streamsize max_n) override {
+    // hides basic_streambuf::sgetn so can avoid the virtual function dispatch if the compiler is not aggressive enough
+    inline std::streamsize sgetn(char_type* s, std::streamsize n) noexcept {
+      return this->xsgetn(s, n);
+    }
+
+    inline std::streamsize xsgetn(char_type* s, std::streamsize max_n) noexcept override {
       const auto n_to_read = std::min(buffer_size_ - (cursor_ - buffer_), max_n);
       std::memcpy(s, cursor_, n_to_read * sizeof(char_type));
       cursor_ += n_to_read;

--- a/ttg/ttg/serialization/stream.h
+++ b/ttg/ttg/serialization/stream.h
@@ -97,7 +97,7 @@ namespace ttg::detail {
    public:
     using std::streambuf::streambuf;
 
-    byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+    byte_istreambuf(const char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
 
     // hides basic_streambuf::sgetn so can avoid the virtual function dispatch if the compiler is not aggressive enough
     std::streamsize sgetn(char_type* s, std::streamsize n) noexcept {
@@ -112,8 +112,8 @@ namespace ttg::detail {
     }
 
    private:
-    char_type* buffer_;
-    char_type* cursor_;  // current location in buffer_
+    const char_type* buffer_;
+    const char_type* cursor_;  // current location in buffer_
     std::streamsize buffer_size_;
   };
 

--- a/ttg/ttg/serialization/stream.h
+++ b/ttg/ttg/serialization/stream.h
@@ -6,6 +6,7 @@
 #define TTG_SERIALIZATION_STREAM_H
 
 #include <streambuf>
+#include <cstring>
 
 namespace ttg::detail {
 
@@ -64,6 +65,46 @@ namespace ttg::detail {
    private:
     std::size_t current_item_ = 0;
     const std::vector<std::pair<const void*, std::size_t>>& iovec_;
+  };
+
+  /// streambuf that writes bytes to a buffer in memory
+  class byte_ostreambuf : public std::streambuf {
+   public:
+    using std::streambuf::streambuf;
+
+    byte_ostreambuf(char_type* buffer, std::streamsize buffer_size = std::numeric_limits<std::streamsize>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+
+    std::streamsize xsputn(const char_type* s, std::streamsize n) override {
+      assert((cursor_ - buffer_) + n <= buffer_size_);
+      std::memcpy(cursor_, s, n * sizeof(char_type));
+      cursor_ += n;
+      return n;
+    }
+
+   private:
+    char_type* buffer_;
+    char_type* cursor_;  // current location in buffer_
+    std::streamsize buffer_size_;
+  };
+
+  /// streambuf that writes bytes to a buffer in memory
+  class byte_istreambuf : public std::streambuf {
+   public:
+    using std::streambuf::streambuf;
+
+    byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+
+    std::streamsize xsgetn(char_type* s, std::streamsize max_n) override {
+      const auto n_to_read = std::min(buffer_size_ - (cursor_ - buffer_), max_n);
+      std::memcpy(s, cursor_, n_to_read * sizeof(char_type));
+      cursor_ += n_to_read;
+      return n_to_read;
+    }
+
+   private:
+    char_type* buffer_;
+    char_type* cursor_;  // current location in buffer_
+    std::streamsize buffer_size_;
   };
 
 }  // namespace ttg::detail

--- a/ttg/ttg/serialization/stream.h
+++ b/ttg/ttg/serialization/stream.h
@@ -72,14 +72,14 @@ namespace ttg::detail {
    public:
     using std::streambuf::streambuf;
 
-    inline byte_ostreambuf(char_type* buffer, std::streamsize buffer_size = std::numeric_limits<std::streamsize>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+    byte_ostreambuf(char_type* buffer, std::streamsize buffer_size = std::numeric_limits<std::streamsize>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
 
     // hides basic_streambuf::sputn so can avoid the virtual function dispatch if the compiler is not aggressive enough
-    inline std::streamsize sputn(const char_type* s, std::streamsize n) noexcept {
+    std::streamsize sputn(const char_type* s, std::streamsize n) noexcept {
       return this->xsputn(s, n);
     }
 
-    inline std::streamsize xsputn(const char_type* s, std::streamsize n) noexcept override {
+    std::streamsize xsputn(const char_type* s, std::streamsize n) noexcept override final {
       assert((cursor_ - buffer_) + n <= buffer_size_);
       std::memcpy(cursor_, s, n * sizeof(char_type));
       cursor_ += n;
@@ -97,14 +97,14 @@ namespace ttg::detail {
    public:
     using std::streambuf::streambuf;
 
-    inline byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
+    byte_istreambuf(char_type* buffer, std::size_t buffer_size = std::numeric_limits<std::size_t>::max()) : buffer_(buffer), cursor_(buffer_), buffer_size_(buffer_size) {}
 
     // hides basic_streambuf::sgetn so can avoid the virtual function dispatch if the compiler is not aggressive enough
-    inline std::streamsize sgetn(char_type* s, std::streamsize n) noexcept {
+    std::streamsize sgetn(char_type* s, std::streamsize n) noexcept {
       return this->xsgetn(s, n);
     }
 
-    inline std::streamsize xsgetn(char_type* s, std::streamsize max_n) noexcept override {
+    std::streamsize xsgetn(char_type* s, std::streamsize max_n) noexcept override final {
       const auto n_to_read = std::min(buffer_size_ - (cursor_ - buffer_), max_n);
       std::memcpy(s, cursor_, n_to_read * sizeof(char_type));
       cursor_ += n_to_read;


### PR DESCRIPTION
"optimized" archive provided by TTG for Boost serialization into in-memory buffers uses Boost infrastructure (`boost::archive::binary_{i,o}archive_impl`) that makes virtual function calls that cannot be inlined at compile time (see #274 ). This addresses the issue.