### PR TITLE
Add devicemap to spmm benchmark

### DIFF
--- a/examples/spmm/spmm_cuda.cc
+++ b/examples/spmm/spmm_cuda.cc
@@ -787,7 +787,11 @@ class SpMM25D {
         , a_rowidx_to_colidx_(a_rowidx_to_colidx)
         , b_colidx_to_rowidx_(b_colidx_to_rowidx) {
       this->set_priomap([this](const Key<3> &ijk) { return this->prio(ijk); });  // map a key to an integral priority value
-
+      auto num_devices = ttg::device::num_devices();
+      this->set_devicemap(
+        [num_devices](const Key<3> &ijk){
+          return ((((uint64_t)ijk[0]) << 32) + ijk[1]) % num_devices;
+        });
       // for each {i,j} determine first k that contributes AND belongs to this node,
       // initialize input {i,j,first_k} flow to 0
       for (auto i = 0ul; i != a_rowidx_to_colidx_.size(); ++i) {

--- a/examples/spmm/spmm_cuda.cc
+++ b/examples/spmm/spmm_cuda.cc
@@ -1348,7 +1348,6 @@ static void initBlSpHardCoded(const std::function<int(const Key<2> &)> &keymap, 
   a_colidx_to_rowidx[3].emplace_back(0);  // A[0][3]
 
   A.setFromTriplets(A_elements.begin(), A_elements.end());
-  std::cout << "A_elements.begin()" << A_elements.begin() << "A_elements.end()" << A_elements.end() << "\n";
 
   if (buildRefs && 0 == rank) {
     Aref.setFromTriplets(Aref_elements.begin(), Aref_elements.end());


### PR DESCRIPTION
Add a simple device mapping for the SPMM benchmark. This mapping mashes together `i` and `j` such that all `k` for `[i, j]` run on the same device. Maybe there are better approaches?

Here is the performance on Seawulf:

1 device:

```
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.163009 gflops/s= 3952.21
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.115536 gflops/s= 5576.14
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.115596 gflops/s= 5573.25
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.104487 gflops/s= 6165.79
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.104266 gflops/s= 6178.86
```

2 devices without mapping:

```
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.2646 gflops/s= 2434.79
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.370376 gflops/s= 1739.44
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.413399 gflops/s= 1558.41
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.411325 gflops/s= 1566.27
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.27798 gflops/s= 2317.6
```

2 devices with mapping:

```
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.120567 gflops/s= 5343.46
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.076282 gflops/s= 8445.57
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.076096 gflops/s= 8466.21
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.075933 gflops/s= 8484.39
TTG-PARSEC PxQxR=   1 1 1 1 average_NB= 1.00033e+06 M= 1200 N= 16384 K= 16384 t= 1024 T=1024 Tiling= RandomIrregularTiling A_density= 1 B_density= 1 gflops= 644.245 seconds= 0.08367 gflops/s= 7699.83
```