### PR TITLE
Upstream improvements needed for MRA on devices

### DIFF
--- a/ttg/ttg/buffer.h
+++ b/ttg/ttg/buffer.h
@@ -1,11 +1,13 @@
 #ifndef TTG_BUFFER_H
 #define TTG_BUFFER_H
 
+#include <memory>
+
 #include "ttg/fwd.h"
 
 namespace ttg {
 
-template<typename T, typename Allocator = std::allocator<T>>
+template<typename T, typename Allocator = std::allocator<std::decay_t<T>>>
 using Buffer = TTG_IMPL_NS::Buffer<T, Allocator>;
 
 } // namespace ttg

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -51,8 +51,6 @@ struct Buffer : public detail::ttg_parsec_data_wrapper_t
 
   static_assert(std::is_trivially_copyable_v<element_type>,
                 "Only trivially copyable types are supported for devices.");
-  static_assert(std::is_default_constructible_v<element_type>,
-                "Only default constructible types are supported for devices.");
 
 private:
   using delete_fn_t = std::function<void(element_type*)>;

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -55,7 +55,7 @@ namespace ttg_parsec {
   static void ttg_broadcast(ttg::World world, T &data, int source_rank);
 
   /* device definitions */
-  template<typename T, typename Allocator = std::allocator<T>>
+  template<typename T, typename Allocator = std::allocator<std::decay_t<T>>>
   struct Buffer;
 
   template<typename T>

--- a/ttg/ttg/parsec/task.h
+++ b/ttg/ttg/parsec/task.h
@@ -162,7 +162,10 @@ namespace ttg_parsec {
         parsec_task.priority = 0;
 
         // TODO: can we avoid this?
-        for (int i = 0; i < MAX_PARAM_COUNT; ++i) { this->parsec_task.data[i].data_in = nullptr; }
+        for (int i = 0; i < MAX_PARAM_COUNT; ++i) {
+          this->parsec_task.data[i].data_in  = nullptr;
+          this->parsec_task.data[i].data_out = nullptr;
+        }
       }
 
       parsec_ttg_task_base_t(parsec_thread_mempool_t *mempool, parsec_task_class_t *task_class,
@@ -184,7 +187,10 @@ namespace ttg_parsec {
         parsec_task.chore_mask = 1<<0;
 
         // TODO: can we avoid this?
-        for (int i = 0; i < MAX_PARAM_COUNT; ++i) { this->parsec_task.data[i].data_in = nullptr; }
+        for (int i = 0; i < MAX_PARAM_COUNT; ++i) {
+          this->parsec_task.data[i].data_in  = nullptr;
+          this->parsec_task.data[i].data_out = nullptr;
+        }
       }
 
     public:
@@ -305,6 +311,15 @@ namespace ttg_parsec {
           return TT::template static_op<Space>(&this->parsec_task);
         } else {
           return TT::template device_static_op<Space>(&this->parsec_task);
+        }
+      }
+
+      template<ttg::ExecutionSpace Space>
+      parsec_hook_return_t invoke_evaluate() {
+        if constexpr (Space == ttg::ExecutionSpace::Host) {
+          return PARSEC_HOOK_RETURN_DONE;
+        } else {
+          return TT::template device_static_evaluate<Space>(&this->parsec_task);
         }
       }
 

--- a/ttg/ttg/parsec/ttg_data_copy.h
+++ b/ttg/ttg/parsec/ttg_data_copy.h
@@ -65,14 +65,11 @@ namespace ttg_parsec {
           data->device_copies[0]->flags ^= TTG_PARSEC_DATA_FLAG_REGISTERED;
         }
 #endif // PARSEC_HAVE_DEV_CUDA_SUPPORT
-        //std::fprintf(stderr, "parsec_data_destroy %p device_copy[0] %p\n", data, data->device_copies[0]);
-        //parsec_data_destroy(data);
         assert(data->device_copies[0] != nullptr);
         auto copy = data->device_copies[0];
         parsec_data_copy_detach(data, data->device_copies[0], 0);
         PARSEC_OBJ_RELEASE(copy);
         PARSEC_OBJ_RELEASE(data);
-
       }
 
       static void delete_null_parsec_data(parsec_data_t *) {
@@ -81,7 +78,7 @@ namespace ttg_parsec {
 
     protected:
 
-      /* remove the the data from the owning data copy */
+      /* remove the data from the owning data copy */
       void remove_from_owner();
 
       /* add the data to the owning data copy */
@@ -461,6 +458,7 @@ namespace ttg_parsec {
       value_type m_value;
 
       template<typename T>
+      requires(std::constructible_from<ValueT, T>)
       ttg_data_value_copy_t(T&& value)
       : ttg_data_copy_container_setter(this)
       , ttg_data_copy_t()
@@ -562,18 +560,13 @@ namespace ttg_parsec {
     : m_data(std::move(other.m_data))
     , m_ttg_copy(detail::ttg_data_copy_container())
     {
-      /* the ttg_data_copy may have moved us already */
-      //if (other.m_ttg_copy != m_ttg_copy) {
-        // try to remove the old buffer from the *old* ttg_copy
-        other.remove_from_owner();
+      // try to remove the old buffer from the *old* ttg_copy
+      other.remove_from_owner();
 
-        // register with the new ttg_copy
-        if (nullptr != m_ttg_copy) {
-          m_ttg_copy->add_device_data(this);
-        }
-      //} else {
-      //  other.m_ttg_copy = nullptr;
-      //}
+      // register with the new ttg_copy
+      if (nullptr != m_ttg_copy) {
+        m_ttg_copy->add_device_data(this);
+      }
     }
 
     inline


### PR DESCRIPTION
Set of changes made while implementing the first MRA kernels with device support. More to come but I wanted to get these out.

Summary:

- Allow specifying the scope (allocate/syncin) on buffers. This is useful for data that is first produced on the device to avoid the initial transfer.
- Allowing `const T` on `ttg::Buffer` to specify that the content of the buffer is immutable.
- Device-side bindings for `broadcastk`
- Deferring errors as long as possible if a type is not copyable. We will try to defer the mutating task until all consumers of the object have completed. Only if we find a second mutating task on the same object we have to throw our hands up.
- Introduce `ttg::device::Stream` representing a device stream object.
- Couple of minor fixes

I tried to break down the changes into individual commits for easier review.