### PR TITLE
PaRSEC: check for universal peer access

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1086,7 +1086,7 @@ namespace ttg_parsec {
         parsec_device_gpu_module_t *gpu_device = (parsec_device_gpu_module_t*)device;
         for (int j = 0; (j < parsec_nb_devices) && all_peer_access; ++j) {
           if (PARSEC_DEV_IS_GPU(device->type)) {
-            all_peer_access &= (gpu_device->peer_access_mask & j);
+            all_peer_access = all_peer_access && (gpu_device->peer_access_mask & (1<<j));
           }
         }
       }


### PR DESCRIPTION
Check whether thinks that all devices can access the memory of their peers. If so, we do not need to push modified data back to the host as PaRSEC will use D2D transfers instead of the host copy. We currently stick to the owner-computes model so data will always be modified on the same device and may only be read on a different device.