### PR TITLE
Flexible device inputs

### DIFF
--- a/tests/unit/device_coro.cc
+++ b/tests/unit/device_coro.cc
@@ -426,13 +426,26 @@ TEST_CASE("Device", "coro") {
 #endif // TTG_HAVE_CUDA
       }
     };
-
     auto tt = ttg::make_tt<ttg::ExecutionSpace::CUDA>(fn, ttg::edges(edge), ttg::edges(edge),
                                                       "device_task", {"edge_in"}, {"edge_out"});
     ttg::make_graph_executable(tt);
     if (ttg::default_execution_context().rank() == 0) tt->invoke(0, value_t{});
     ttg::ttg_fence(ttg::default_execution_context());
   }
+
+  SECTION("empty-select") {
+    ttg::Edge<void, void> edge;
+    auto fn = []() -> ttg::device::Task {
+      co_await ttg::device::select();
+      /* nothing else to do */
+    };
+    auto tt = ttg::make_tt<ttg::ExecutionSpace::CUDA>(fn, ttg::edges(edge), ttg::edges(),
+                                                      "device_task", {"edge_in"}, {"edge_out"});
+    ttg::make_graph_executable(tt);
+    tt->invoke();
+    ttg::ttg_fence(ttg::default_execution_context());
+  };
+
 }
 
 #endif // TTG_IMPL_DEVICE_SUPPORT

--- a/ttg/CMakeLists.txt
+++ b/ttg/CMakeLists.txt
@@ -210,6 +210,7 @@ if (TARGET MADworld)
   set(ttg-mad-headers
           ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/buffer.h
           ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/device.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/devicefunc.h
           ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/fwd.h
           ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/import.h
           ${CMAKE_CURRENT_SOURCE_DIR}/ttg/madness/ttg.h

--- a/ttg/ttg.h
+++ b/ttg/ttg.h
@@ -4,6 +4,12 @@
 #include "ttg/config.h"
 #include "ttg/fwd.h"
 
+#if defined(TTG_USE_PARSEC)
+#include "ttg/parsec/ttg.h"
+#elif defined(TTG_USE_MADNESS)
+#include "ttg/madness/ttg.h"
+#endif  // TTG_USE_{PARSEC|MADNESS}
+
 #include "ttg/runtimes.h"
 #include "ttg/util/demangle.h"
 #include "ttg/util/hash.h"
@@ -36,12 +42,6 @@
 #include "ttg/devicescope.h"
 #include "ttg/device/device.h"
 #include "ttg/device/task.h"
-
-#if defined(TTG_USE_PARSEC)
-#include "ttg/parsec/ttg.h"
-#elif defined(TTG_USE_MADNESS)
-#include "ttg/madness/ttg.h"
-#endif  // TTG_USE_{PARSEC|MADNESS}
 
 // these headers use the default backend
 #include "ttg/run.h"

--- a/ttg/ttg/base/tt.h
+++ b/ttg/ttg/base/tt.h
@@ -10,6 +10,7 @@
 
 #include "ttg/base/terminal.h"
 #include "ttg/util/demangle.h"
+#include "ttg/util/trace.h"
 
 namespace ttg {
 

--- a/ttg/ttg/buffer.h
+++ b/ttg/ttg/buffer.h
@@ -4,11 +4,31 @@
 #include <memory>
 
 #include "ttg/fwd.h"
+#include "ttg/util/meta.h"
 
 namespace ttg {
 
 template<typename T, typename Allocator = std::allocator<std::decay_t<T>>>
 using Buffer = TTG_IMPL_NS::Buffer<T, Allocator>;
+
+namespace meta {
+
+  /* Specialize some traits */
+
+  template<typename T, typename A>
+  struct is_buffer<ttg::Buffer<T, A>> : std::true_type
+  { };
+
+  template<typename T, typename A>
+  struct is_buffer<const ttg::Buffer<T, A>> : std::true_type
+  { };
+
+  /* buffers are const if their value types are const */
+  template<typename T, typename A>
+  struct is_const<ttg::Buffer<T, A>> : std::is_const<T>
+  { };
+
+} // namespace meta
 
 } // namespace ttg
 

--- a/ttg/ttg/device/device.h
+++ b/ttg/ttg/device/device.h
@@ -51,6 +51,10 @@ namespace ttg::device {
     bool is_invalid() const {
       return (m_space == ttg::ExecutionSpace::Invalid);
     }
+
+    static Device host() {
+      return {};
+    }
   };
 } // namespace ttg::device
 

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -9,6 +9,7 @@
 #include "ttg/fwd.h"
 #include "ttg/impl_selector.h"
 #include "ttg/ptr.h"
+#include "ttg/devicescope.h"
 
 #ifdef TTG_HAVE_COROUTINE
 

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -18,7 +18,9 @@ namespace ttg::device {
 
     struct device_input_data_t {
       using impl_data_t = decltype(TTG_IMPL_NS::buffer_data(std::declval<ttg::Buffer<int>>()));
-      : impl_data(data), scope(scope), is_const(is_const), is_scratch(is_scratch)
+
+      device_input_data_t(impl_data_t data, ttg::scope scope, bool isconst, bool isscratch)
+      : impl_data(data), scope(scope), is_const(isconst), is_scratch(isscratch)
       { }
       impl_data_t impl_data;
       ttg::scope scope;
@@ -38,8 +40,8 @@ namespace ttg::device {
       return std::array{
                 device_input_data_t{TTG_IMPL_NS::buffer_data(std::get<Is>(a.ties)),
                                     std::get<Is>(a.ties).scope(),
-                                    ttg::meta::is_const_v<std::tuple_element<Is, arg_types>>,
-                                    ttg::meta::is_devicescratch_v<std::tuple_element<Is, arg_types>>}...};
+                                    ttg::meta::is_const_v<std::tuple_element_t<Is, arg_types>>,
+                                    ttg::meta::is_devicescratch_v<std::tuple_element_t<Is, arg_types>>}...};
     }
   }  // namespace detail
 

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -509,8 +509,9 @@ namespace ttg::device {
             ttg::Runtime Runtime = ttg::ttg_runtime>
   inline detail::send_t broadcast(rangeT &&keylist, valueT &&value) {
     ttg::detail::value_copy_handler<Runtime> copy_handler;
-    return detail::send_t{broadcast_coro<i>(std::tie(keylist), copy_handler(std::forward<valueT>(value)),
-                                            std::move(copy_handler))};
+    return detail::send_t{detail::broadcast_coro<i>(std::tie(keylist),
+                                                    copy_handler(std::forward<valueT>(value)),
+                                                    std::move(copy_handler))};
   }
 
   /* overload with explicit terminals and keylist passed by const reference */

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -34,9 +34,10 @@ namespace ttg::device {
     template<typename... Ts, std::size_t... Is>
     auto extract_buffer_data(detail::to_device_t<Ts...>& a, std::index_sequence<Is...>) {
       return std::array{
-                {TTG_IMPL_NS::buffer_data(std::get<Is>(a.ties)),
-                 std::get<Is>(a.ties).scope(), std::is_const_v<std::tuple_element<Is, decltype(a.ties)>>,
-                 ttg::meta::is_devicescratch_v<std::tuple_element<Is, decltype(a.ties)>>}...};
+                device_input_data_t{TTG_IMPL_NS::buffer_data(std::get<Is>(a.ties)),
+                                    std::get<Is>(a.ties).scope(),
+                                    std::is_const_v<std::tuple_element<Is, decltype(a.ties)>>,
+                                    ttg::meta::is_devicescratch_v<std::tuple_element<Is, decltype(a.ties)>>}...};
     }
   }  // namespace detail
 
@@ -49,13 +50,13 @@ namespace ttg::device {
     template<typename... Args>
     Input(Args&&... args)
     : m_data{{TTG_IMPL_NS::buffer_data(args), args.scope(),
-              std::is_const_v<std::decay_t<Args>>,
-              ttg::meta::is_devicescratch_v<Args>}...}
+              std::is_const_v<std::remove_reference_t<Args>>,
+              ttg::meta::is_devicescratch_v<std::remove_reference_t<Args>>}...}
     { }
 
     template<typename T>
     void add(T&& v) {
-      using type = std::decay_t<T>;
+      using type = std::remove_reference_t<T>;
       m_data.emplace_back(TTG_IMPL_NS::buffer_data(v), v.scope(), std::is_const_v<type>,
                           ttg::meta::is_devicescratch_v<type>);
     }

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -37,7 +37,7 @@ namespace ttg::device {
     template<typename... Ts, std::size_t... Is>
     auto extract_buffer_data(detail::to_device_t<Ts...>& a, std::index_sequence<Is...>) {
       using arg_types = std::tuple<Ts...>;
-      return std::array{
+      return std::array<device_input_data_t, sizeof...(Ts)>{
                 device_input_data_t{TTG_IMPL_NS::buffer_data(std::get<Is>(a.ties)),
                                     std::get<Is>(a.ties).scope(),
                                     ttg::meta::is_const_v<std::tuple_element_t<Is, arg_types>>,

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -51,7 +51,7 @@ namespace ttg::device {
     Input(Args&&... args)
     : m_data{{TTG_IMPL_NS::buffer_data(args), args.scope(),
               std::is_const_v<std::remove_reference_t<Args>>,
-              ttg::meta::is_devicescratch_v<std::remove_reference_t<Args>>}...}
+              ttg::meta::is_devicescratch_v<std::decay_t<Args>>}...}
     { }
 
     template<typename T>

--- a/ttg/ttg/device/task.h
+++ b/ttg/ttg/device/task.h
@@ -18,7 +18,8 @@ namespace ttg::device {
 
     struct device_input_data_t {
       using impl_data_t = decltype(TTG_IMPL_NS::buffer_data(std::declval<ttg::Buffer<int>>()));
-
+      : impl_data(data), scope(scope), is_const(is_const), is_scratch(is_scratch)
+      { }
       impl_data_t impl_data;
       ttg::scope scope;
       bool is_const;
@@ -33,11 +34,12 @@ namespace ttg::device {
     /* extract buffer information from to_device_t */
     template<typename... Ts, std::size_t... Is>
     auto extract_buffer_data(detail::to_device_t<Ts...>& a, std::index_sequence<Is...>) {
+      using arg_types = std::tuple<Ts...>;
       return std::array{
                 device_input_data_t{TTG_IMPL_NS::buffer_data(std::get<Is>(a.ties)),
                                     std::get<Is>(a.ties).scope(),
-                                    std::is_const_v<std::tuple_element<Is, decltype(a.ties)>>,
-                                    ttg::meta::is_devicescratch_v<std::tuple_element<Is, decltype(a.ties)>>}...};
+                                    ttg::meta::is_const_v<std::tuple_element<Is, arg_types>>,
+                                    ttg::meta::is_devicescratch_v<std::tuple_element<Is, arg_types>>}...};
     }
   }  // namespace detail
 

--- a/ttg/ttg/devicescratch.h
+++ b/ttg/ttg/devicescratch.h
@@ -3,6 +3,7 @@
 
 #include "ttg/devicescope.h"
 #include "ttg/fwd.h"
+#include "ttg/util/meta.h"
 
 namespace ttg {
 
@@ -13,6 +14,24 @@ template<typename T>
 auto make_scratch(T* val, ttg::scope scope, std::size_t count = 1) {
   return devicescratch<T>(val, scope, count);
 }
+
+namespace meta {
+
+  /* Specialize some traits */
+
+  template<typename T>
+  struct is_devicescratch<ttg::devicescratch<T>> : std::true_type
+  { };
+
+  template<typename T>
+  struct is_devicescratch<const ttg::devicescratch<T>> : std::true_type
+  { };
+
+  template<typename T>
+  struct is_const<ttg::devicescratch<T>> : std::is_const<T>
+  { };
+
+} // namespace meta
 
 } // namespace ttg
 

--- a/ttg/ttg/madness/buffer.h
+++ b/ttg/ttg/madness/buffer.h
@@ -186,6 +186,10 @@ public:
     throw std::runtime_error("not implemented yet");
   }
 
+  bool empty() const {
+    return (m_host_data == nullptr);
+  }
+
   /* TODO: can we do this automatically?
    * Pin the memory on all devices we currently track.
    * Pinned memory won't be released by PaRSEC and can be used

--- a/ttg/ttg/madness/buffer.h
+++ b/ttg/ttg/madness/buffer.h
@@ -3,6 +3,8 @@
 
 #include "ttg/serialization/traits.h"
 
+#include "ttg/device/device.h"
+
 namespace ttg_madness {
 
 /// A runtime-managed buffer mirrored between host and device memory

--- a/ttg/ttg/madness/buffer.h
+++ b/ttg/ttg/madness/buffer.h
@@ -112,6 +112,12 @@ public:
     /* no-op */
   }
 
+
+  bool is_current_on(ttg::device::Device dev) const {
+    assert(is_valid());
+    return true;
+  }
+
   /* Get the owner device ID, i.e., the last updated
    * device buffer. */
   ttg::device::Device get_owner_device() const {

--- a/ttg/ttg/madness/devicefunc.h
+++ b/ttg/ttg/madness/devicefunc.h
@@ -1,0 +1,30 @@
+#ifndef TTG_MAD_DEVICEFUNC_H
+#define TTG_MAD_DEVICEFUNC_H
+
+#include "ttg/madness/buffer.h"
+
+namespace ttg_madness {
+
+  template<typename T, typename A>
+  auto buffer_data(const Buffer<T, A>& buffer) {
+    /* for now return the internal pointer, should be adapted if ever relevant for madness */
+    return buffer.current_device_ptr();
+  }
+
+  template<typename... Views>
+  inline bool register_device_memory(std::tuple<Views&...> &views)
+  {
+    /* nothing to do here */
+    return true;
+  }
+
+  template<typename T, std::size_t N>
+  inline bool register_device_memory(const ttg::span<T, N>& span)
+  {
+    /* nothing to do here */
+    return true;
+  }
+
+} // namespace ttg_madness
+
+#endif // TTG_MAD_DEVICEFUNC_H

--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -3,6 +3,7 @@
 
 #include "ttg/fwd.h"
 #include "ttg/util/typelist.h"
+#include "ttg/util/span.h"
 
 #include <future>
 
@@ -70,6 +71,9 @@ namespace ttg_madness {
 
   template<typename... Views>
   inline bool register_device_memory(std::tuple<Views&...> &views);
+
+  template<typename T, std::size_t N>
+  inline bool register_device_memory(const ttg::span<T, N>& span);
 
   template<typename... Buffer>
   inline void post_device_out(std::tuple<Buffer&...> &b);

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -14,6 +14,9 @@
 #include "ttg/madness/device.h"
 #include "ttg/madness/devicefunc.h"
 
+/* needed for make_tt */
+#include "ttg/device/task.h"
+
 #include "ttg/runtimes.h"
 #include "ttg/tt.h"
 #include "ttg/util/bug.h"

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -14,6 +14,7 @@
 #include "ttg/base/tt.h"
 #include "ttg/func.h"
 #include "ttg/madness/device.h"
+#include "ttg/madness/devicefunc.h"
 #include "ttg/runtimes.h"
 #include "ttg/tt.h"
 #include "ttg/util/bug.h"

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -8,13 +8,12 @@
 
 #include "ttg/impl_selector.h"
 
-/* include ttg header to make symbols available in case this header is included directly */
-#include "../../ttg.h"
 #include "ttg/base/keymap.h"
 #include "ttg/base/tt.h"
 #include "ttg/func.h"
 #include "ttg/madness/device.h"
 #include "ttg/madness/devicefunc.h"
+
 #include "ttg/runtimes.h"
 #include "ttg/tt.h"
 #include "ttg/util/bug.h"
@@ -27,6 +26,9 @@
 #include "ttg/util/void.h"
 #include "ttg/world.h"
 #include "ttg/coroutine.h"
+
+/* include ttg header to make symbols available in case this header is included directly */
+#include "../../ttg.h"
 
 #include <array>
 #include <cassert>

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -213,9 +213,9 @@ protected:
 
     auto invoke_func_empty_tuple = [&](auto&&... args){
       if constexpr(funcT_receives_input_tuple) {
-        invoke_func_handle_ret(std::tuple<>{}, std::forward<decltype(args)>(args)...);
+        return invoke_func_handle_ret(std::tuple<>{}, std::forward<decltype(args)>(args)...);
       } else {
-        invoke_func_handle_ret(std::forward<decltype(args)>(args)...);
+        return invoke_func_handle_ret(std::forward<decltype(args)>(args)...);
       }
     };
 

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -191,8 +191,23 @@ public:
     m_data->owner_device = parsec_id;
   }
 
+  bool is_current_on(ttg::device::Device dev) const {
+    if (empty()) return true; // empty is current everywhere
+    int parsec_id = detail::ttg_device_to_parsec_device(dev);
+    uint32_t max_version = 0;
+    for (int i = 0; i < parsec_nb_devices; ++i) {
+      if (nullptr == m_data->device_copies[i]) continue;
+      max_version = std::max(max_version, m_data->device_copies[i]->version);
+    }
+    return (m_data->device_copies[parsec_id] &&
+            m_data->device_copies[parsec_id]->version == max_version);
+  }
+
   /* Get the owner device ID, i.e., the last updated
-   * device buffer. */
+   * device buffer.
+   * NOTE: there may be more than one device with the current
+   *       data so the result may not always be what is expected.
+   *       Use is_current_on() to check for a specific device. */
   ttg::device::Device get_owner_device() const {
     assert(is_valid());
     if (empty()) return ttg::device::current_device(); // empty is always valid

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -78,7 +78,12 @@ private:
 
 public:
 
-  Buffer() : Buffer(nullptr, 0)
+  Buffer()
+  : ttg_parsec_data_wrapper_t()
+  , allocator_type()
+  , m_host_data(nullptr)
+  , m_count(0)
+  , m_owned(false)
   { }
 
   /**
@@ -189,6 +194,7 @@ public:
    * device buffer. */
   ttg::device::Device get_owner_device() const {
     assert(is_valid());
+    if (empty()) return ttg::device::current_device(); // empty is always valid
     return detail::parsec_device_to_ttg_device(m_data->owner_device);
   }
 
@@ -248,6 +254,7 @@ public:
   }
 
   const_pointer_type host_ptr() const {
+    if (empty()) return nullptr;
     return static_cast<const_pointer_type>(parsec_data_get_ptr(m_data.get(), 0));
   }
 
@@ -292,11 +299,11 @@ public:
   }
 
   bool is_valid() const {
-    return !!m_data;
+    return (m_count == 0 || m_data);
   }
 
   operator bool() const {
-    return is_valid();
+    return !empty();
   }
 
   std::size_t size() const {

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -363,8 +363,14 @@ public:
           m_data->device_copies[i]->version = 0;
         }
       }
-      m_data->owner_device = 0;
     }
+    m_data->owner_device = 0;
+  }
+
+  ttg::scope scope() const {
+    /* if the host owns the data and has a version of zero we only have to allocate data */
+    return (m_data->device_copies[0]->version == 0 && m_data->owner_device == 0)
+            ? ttg::scope::Allocate : ttg::scope::SyncIn;
   }
 
   void prefer_device(ttg::device::Device dev) {

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -11,6 +11,7 @@
 #include "ttg/util/iovec.h"
 #include "ttg/device/device.h"
 #include "ttg/parsec/device.h"
+#include "ttg/devicescope.h"
 
 #if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
 #include <cuda_runtime.h>
@@ -457,8 +458,6 @@ public:
     }
   }
 #endif // TTG_SERIALIZATION_SUPPORTS_MADNESS
-
-
 };
 
 namespace detail {

--- a/ttg/ttg/parsec/buffer.h
+++ b/ttg/ttg/parsec/buffer.h
@@ -195,6 +195,7 @@ public:
   /* Get the pointer on the currently active device. */
   pointer_type current_device_ptr() {
     assert(is_valid());
+    if (empty()) return nullptr;
     int device_id = detail::ttg_device_to_parsec_device(ttg::device::current_device());
     return static_cast<pointer_type>(m_data->device_copies[device_id]->device_private);
   }
@@ -202,6 +203,7 @@ public:
   /* Get the pointer on the currently active device. */
   const_pointer_type current_device_ptr() const {
     assert(is_valid());
+    if (empty()) return nullptr;
     int device_id = detail::ttg_device_to_parsec_device(ttg::device::current_device());
     return static_cast<const_pointer_type>(m_data->device_copies[device_id]->device_private);
   }
@@ -211,12 +213,14 @@ public:
    *        See \ref ttg::device::current_device for that. */
   pointer_type owner_device_ptr() {
     assert(is_valid());
+    if (empty()) return nullptr;
     return static_cast<pointer_type>(m_data->device_copies[m_data->owner_device]->device_private);
   }
 
   /* get the current device pointer */
   const_pointer_type owner_device_ptr() const {
     assert(is_valid());
+    if (empty()) return nullptr;
     return static_cast<const_pointer_type>(m_data->device_copies[m_data->owner_device]->device_private);
   }
 
@@ -224,6 +228,7 @@ public:
    */
   pointer_type device_ptr_on(const ttg::device::Device& device) {
     assert(is_valid());
+    if (empty()) return nullptr;
     int device_id = detail::ttg_device_to_parsec_device(device);
     return static_cast<pointer_type>(parsec_data_get_ptr(m_data.get(), device_id));
   }
@@ -232,11 +237,13 @@ public:
    */
   const_pointer_type device_ptr_on(const ttg::device::Device& device) const {
     assert(is_valid());
+    if (empty()) return nullptr;
     int device_id = detail::ttg_device_to_parsec_device(device);
     return static_cast<const_pointer_type>(parsec_data_get_ptr(m_data.get(), device_id));
   }
 
   pointer_type host_ptr() {
+    if (empty()) return nullptr;
     return static_cast<pointer_type>(parsec_data_get_ptr(m_data.get(), 0));
   }
 
@@ -294,6 +301,10 @@ public:
 
   std::size_t size() const {
     return m_count;
+  }
+
+  bool empty() const {
+    return m_count == 0;
   }
 
   /* Reallocate the buffer with count elements */

--- a/ttg/ttg/parsec/devicefunc.h
+++ b/ttg/ttg/parsec/devicefunc.h
@@ -201,10 +201,11 @@ namespace ttg_parsec {
       /* enqueue the transfer into the compute stream to come back once the compute and transfer are complete */
       if (data->owner_device != 0) {
         parsec_device_gpu_module_t *device_module = detail::parsec_ttg_caller->dev_ptr->device;
-        device_module->memcpy_async(device_module, stream,
-                                    data->device_copies[0]->device_private,
-                                    data->device_copies[data->owner_device]->device_private,
-                                    data->nb_elts, parsec_device_gpu_transfer_direction_d2h);
+        int ret = device_module->memcpy_async(device_module, stream,
+                                              data->device_copies[0]->device_private,
+                                              data->device_copies[data->owner_device]->device_private,
+                                              data->nb_elts, parsec_device_gpu_transfer_direction_d2h);
+        assert(ret == PARSEC_SUCCESS);
       }
       if constexpr (sizeof...(Is) > 0) {
         // recursion

--- a/ttg/ttg/parsec/devicefunc.h
+++ b/ttg/ttg/parsec/devicefunc.h
@@ -1,24 +1,14 @@
 #ifndef TTG_PARSEC_DEVICEFUNC_H
 #define TTG_PARSEC_DEVICEFUNC_H
 
-#if defined(TTG_HAVE_CUDART)
-#include <cuda.h>
-#endif
-
 #include "ttg/parsec/task.h"
 #include <parsec.h>
 #include <parsec/mca/device/device_gpu.h>
 
-#if defined(PARSEC_HAVE_DEV_CUDA_SUPPORT)
-#include <parsec/mca/device/cuda/device_cuda.h>
-#elif defined(PARSEC_HAVE_DEV_HIP_SUPPORT)
-#include <parsec/mca/device/hip/device_hip.h>
-#endif // PARSEC_HAVE_DEV_CUDA_SUPPORT
-
 namespace ttg_parsec {
   namespace detail {
     template<typename... Views, std::size_t I, std::size_t... Is>
-    inline bool register_device_memory(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
+    bool register_device_memory(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
       static_assert(I < MAX_PARAM_COUNT,
                     "PaRSEC only supports MAX_PARAM_COUNT device input/outputs. "
                     "Increase MAX_PARAM_COUNT and recompile PaRSEC/TTG.");
@@ -88,7 +78,7 @@ namespace ttg_parsec {
    * with the currently executing task. Returns true if all memory
    * is current on the target device, false if transfers are required. */
   template<typename... Views>
-  inline bool register_device_memory(std::tuple<Views&...> &views) {
+  bool register_device_memory(std::tuple<Views&...> &views) {
     bool is_current = true;
     if (nullptr == detail::parsec_ttg_caller) {
       throw std::runtime_error("register_device_memory may only be invoked from inside a task!");
@@ -114,9 +104,87 @@ namespace ttg_parsec {
     return is_current;
   }
 
+  // templated to break circular dependency with fwd.h
+  template<typename T, std::size_t N>
+  bool register_device_memory(const ttg::span<T, N>& span)
+  {
+
+    if (nullptr == detail::parsec_ttg_caller) {
+      throw std::runtime_error("register_device_memory may only be invoked from inside a task!");
+    }
+
+    if (nullptr == detail::parsec_ttg_caller->dev_ptr) {
+      throw std::runtime_error("register_device_memory called inside a non-gpu task!");
+    }
+
+    uint8_t i; // only limited number of flows
+    detail::parsec_ttg_task_base_t *caller = detail::parsec_ttg_caller;
+    assert(nullptr != caller->dev_ptr);
+    parsec_gpu_task_t *gpu_task = caller->dev_ptr->gpu_task;
+    parsec_flow_t *flows = caller->dev_ptr->flows;
+
+    bool is_current = false;
+    for (i = 0; i < span.size(); ++i) {
+      /* get_parsec_data is overloaded for buffer and devicescratch */
+      parsec_data_t* data = span[i].impl_data;
+      /* TODO: check whether the device is current */
+      bool is_const = span[i].is_const;
+      ttg::scope scope = span[i].scope;
+
+      if (nullptr != data) {
+        auto access = PARSEC_FLOW_ACCESS_RW;
+        if (ttg::scope::Allocate == scope) {
+          access = PARSEC_FLOW_ACCESS_WRITE;
+        } else if (is_const) {
+          access = PARSEC_FLOW_ACCESS_READ;
+        }
+
+        /* build the flow */
+        /* TODO: reuse the flows of the task class? How can we control the sync direction then? */
+        flows[i] = parsec_flow_t{.name = nullptr,
+                                .sym_type = PARSEC_SYM_INOUT,
+                                .flow_flags = static_cast<uint8_t>(access),
+                                .flow_index = i,
+                                .flow_datatype_mask = ~0 };
+
+        gpu_task->flow_nb_elts[i] = data->nb_elts; // size in bytes
+        gpu_task->flow[i] = &flows[i];
+
+        /* set the input data copy, parsec will take care of the transfer
+        * and the buffer will look at the parsec_data_t for the current pointer */
+        //detail::parsec_ttg_caller->parsec_task.data[I].data_in = data->device_copies[data->owner_device];
+        assert(nullptr != data->device_copies[0]->original);
+        caller->parsec_task.data[i].data_in = data->device_copies[0];
+        caller->parsec_task.data[i].source_repo_entry = NULL;
+
+      } else {
+        /* ignore the flow */
+        flows[i] = parsec_flow_t{.name = nullptr,
+                                 .sym_type = PARSEC_FLOW_ACCESS_NONE,
+                                 .flow_flags = 0,
+                                 .flow_index = i,
+                                 .flow_datatype_mask = ~0 };
+        gpu_task->flow[i] = &flows[i];
+        gpu_task->flow_nb_elts[i] = 0; // size in bytes
+        caller->parsec_task.data[i].data_in = nullptr;
+      }
+    }
+
+    /* reset all remaining entries in the current task */
+    for (; i < MAX_PARAM_COUNT; ++i) {
+      detail::parsec_ttg_caller->parsec_task.data[i].data_in = nullptr;
+      detail::parsec_ttg_caller->dev_ptr->flows[i].flow_flags = PARSEC_FLOW_ACCESS_NONE;
+      detail::parsec_ttg_caller->dev_ptr->flows[i].flow_index = i;
+      detail::parsec_ttg_caller->dev_ptr->gpu_task->flow[i] = &detail::parsec_ttg_caller->dev_ptr->flows[i];
+      detail::parsec_ttg_caller->dev_ptr->gpu_task->flow_nb_elts[i] = 0;
+    }
+    // we cannot allow the calling thread to submit kernels so say we're not ready
+    return is_current;
+  }
+
   namespace detail {
     template<typename... Views, std::size_t I, std::size_t... Is, bool DeviceAvail = false>
-    inline void mark_device_out(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
+    void mark_device_out(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
 
       using view_type = std::remove_reference_t<std::tuple_element_t<I, std::tuple<Views&...>>>;
       auto& view = std::get<I>(views);
@@ -141,7 +209,7 @@ namespace ttg_parsec {
   } // namespace detail
 
   template<typename... Buffer>
-  inline void mark_device_out(std::tuple<Buffer&...> &b) {
+  void mark_device_out(std::tuple<Buffer&...> &b) {
 
     if (nullptr == detail::parsec_ttg_caller) {
       throw std::runtime_error("mark_device_out may only be invoked from inside a task!");
@@ -157,7 +225,7 @@ namespace ttg_parsec {
   namespace detail {
 
     template<typename... Views, std::size_t I, std::size_t... Is>
-    inline void post_device_out(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
+    void post_device_out(std::tuple<Views&...> &views, std::index_sequence<I, Is...>) {
 
       using view_type = std::remove_reference_t<std::tuple_element_t<I, std::tuple<Views&...>>>;
 
@@ -176,9 +244,17 @@ namespace ttg_parsec {
       }
     }
   } // namespace detail
+
   template<typename... Buffer>
-  inline void post_device_out(std::tuple<Buffer&...> &b) {
+  void post_device_out(std::tuple<Buffer&...> &b) {
     detail::post_device_out(b, std::index_sequence_for<Buffer...>{});
+  }
+
+  template<typename T>
+  parsec_data_t* buffer_data(T&& buffer) {
+    using view_type = std::remove_reference_t<T>;
+    static_assert(ttg::meta::is_buffer_v<view_type> || ttg::meta::is_devicescratch_v<view_type>);
+    return detail::get_parsec_data(buffer);
   }
 
 } // namespace ttg_parsec

--- a/ttg/ttg/parsec/devicefunc.h
+++ b/ttg/ttg/parsec/devicefunc.h
@@ -127,9 +127,9 @@ namespace ttg_parsec {
     for (i = 0; i < span.size(); ++i) {
       /* get_parsec_data is overloaded for buffer and devicescratch */
       parsec_data_t* data = span[i].impl_data;
-      /* TODO: check whether the device is current */
-      bool is_const = span[i].is_const;
       ttg::scope scope = span[i].scope;
+      bool is_const = span[i].is_const;
+      bool is_scratch = span[i].is_scratch;
 
       if (nullptr != data) {
         auto access = PARSEC_FLOW_ACCESS_RW;
@@ -137,6 +137,11 @@ namespace ttg_parsec {
           access = PARSEC_FLOW_ACCESS_WRITE;
         } else if (is_const) {
           access = PARSEC_FLOW_ACCESS_READ;
+        }
+
+        if (is_scratch) {
+          /* mark the flow as temporary so we can discard it easily */
+          access |= TTG_PARSEC_FLOW_ACCESS_TMP;
         }
 
         /* build the flow */

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -3,8 +3,11 @@
 
 #include "ttg/fwd.h"
 #include "ttg/util/typelist.h"
+#include "ttg/util/span.h"
 
 #include <future>
+
+#include <parsec.h>
 
 extern "C" struct parsec_context_s;
 
@@ -74,20 +77,21 @@ namespace ttg_parsec {
   inline Ptr<std::decay_t<T>> get_ptr(T&& obj);
 
   template<typename... Views>
-  inline bool register_device_memory(std::tuple<Views&...> &views);
+  bool register_device_memory(std::tuple<Views&...> &views);
+
+  template<typename T, std::size_t N>
+  bool register_device_memory(const ttg::span<T, N>& span);
 
   template<typename... Buffer>
-  inline void post_device_out(std::tuple<Buffer&...> &b);
+  void post_device_out(std::tuple<Buffer&...> &b);
 
   template<typename... Buffer>
-  inline void mark_device_out(std::tuple<Buffer&...> &b);
+  void mark_device_out(std::tuple<Buffer&...> &b);
 
   inline int num_devices();
 
-#if 0
-  template<typename... Args>
-  inline std::pair<bool, std::tuple<ptr<std::decay_t<Args>>...>> get_ptr(Args&&... args);
-#endif
+  template<typename T>
+  parsec_data_t* buffer_data(T&& buffer);
 
 }  // namespace ttg_parsec
 

--- a/ttg/ttg/parsec/parsec-ext.h
+++ b/ttg/ttg/parsec/parsec-ext.h
@@ -4,4 +4,7 @@
 /* HACK: we need this flag on a data copy to indicate whether it has been registered */
 #define TTG_PARSEC_DATA_FLAG_REGISTERED        ((parsec_data_flag_t)1<<2)
 
+/* HACK: mark the flows of device scratch as temporary so that we can easily discard it */
+#define TTG_PARSEC_FLOW_ACCESS_TMP (1<<7)
+
 #endif // TTG_PARSEC_EXT_H

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1467,6 +1467,7 @@ namespace ttg_parsec {
           if (gpu_task->flow[i]->flow_flags & TTG_PARSEC_FLOW_ACCESS_TMP) {
             /* temporary flow, discard by setting it to read-only to avoid evictions */
             const_cast<parsec_flow_t*>(gpu_task->flow[i])->flow_flags = PARSEC_FLOW_ACCESS_READ;
+            task->parsec_task.data.data_out[i]->readers = 1;
           }
         }
       };

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -3445,8 +3445,8 @@ namespace ttg_parsec {
             detail::parsec_ttg_caller->parsec_task.data[flowidx].data_in = data->device_copies[0];
             gpu_task->flow_nb_elts[flowidx] = data->nb_elts;
           }
-          /* need to mark the flow RW to make PaRSEC happy */
-          ((parsec_flow_t *)gpu_task->flow[flowidx])->flow_flags |= PARSEC_FLOW_ACCESS_RW;
+          /* need to mark the flow WRITE to convince PaRSEC that the data changed */
+          ((parsec_flow_t *)gpu_task->flow[flowidx])->flow_flags |= PARSEC_FLOW_ACCESS_WRITE;
           gpu_task->pushout |= 1<<flowidx;
         }
       };

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -37,9 +37,6 @@
 #include "ttg/util/scope_exit.h"
 #include "ttg/util/trace.h"
 #include "ttg/util/typelist.h"
-#ifdef TTG_HAVE_DEVICE
-#include "ttg/device/task.h"
-#endif  // TTG_HAVE_DEVICE
 
 #include "ttg/serialization/data_descriptor.h"
 
@@ -50,6 +47,7 @@
 #include "ttg/parsec/thread_local.h"
 #include "ttg/parsec/devicefunc.h"
 #include "ttg/parsec/ttvalue.h"
+#include "ttg/device/task.h"
 
 #include <algorithm>
 #include <array>

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -3458,8 +3458,7 @@ namespace ttg_parsec {
     std::enable_if_t<!std::is_void_v<std::decay_t<Value>>,
                      void>
     do_prepare_send(const Value &value, RemoteCheckFn&& remote_check) {
-      using valueT = std::tuple_element_t<i, input_values_full_tuple_type>;
-      static constexpr const bool value_is_const = std::is_const_v<valueT>;
+      constexpr const bool value_is_const = std::is_const_v<std::tuple_element_t<i, input_args_type>>;
 
       /* get the copy */
       detail::ttg_data_copy_t *copy;

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1467,7 +1467,7 @@ namespace ttg_parsec {
           if (gpu_task->flow[i]->flow_flags & TTG_PARSEC_FLOW_ACCESS_TMP) {
             /* temporary flow, discard by setting it to read-only to avoid evictions */
             const_cast<parsec_flow_t*>(gpu_task->flow[i])->flow_flags = PARSEC_FLOW_ACCESS_READ;
-            task->parsec_task.data.data_out[i]->readers = 1;
+            task->parsec_task.data[i].data_out->readers = 1;
           }
         }
       };

--- a/ttg/ttg/ptr.h
+++ b/ttg/ttg/ptr.h
@@ -3,6 +3,8 @@
 
 #include "ttg/fwd.h"
 
+#include "ttg/util/meta.h"
+
 namespace ttg {
 
 template<typename T>
@@ -17,6 +19,16 @@ template<typename T>
 inline Ptr<std::decay_t<T>> get_ptr(T&& obj) {
   return TTG_IMPL_NS::get_ptr(std::forward<T>(obj));
 }
+
+namespace meta {
+
+  /* specialize some traits */
+
+  template<typename T>
+  struct is_ptr<ttg::Ptr<T>> : std::true_type
+  { };
+
+} // namespace ptr
 
 #if 0
 namespace detail {

--- a/ttg/ttg/terminal.h
+++ b/ttg/ttg/terminal.h
@@ -588,9 +588,9 @@ namespace ttg {
       for (auto &&successor : this->successors()) {
         assert(successor->get_type() != TerminalBase::Type::Write);
         if (successor->get_type() == TerminalBase::Type::Read) {
-          return static_cast<In<keyT, std::add_const_t<valueT>> *>(successor)->prepare_send(keylist, value);
+          static_cast<In<keyT, std::add_const_t<valueT>> *>(successor)->prepare_send(keylist, value);
         } else if (successor->get_type() == TerminalBase::Type::Consume) {
-          return static_cast<In<keyT, valueT> *>(successor)->prepare_send(keylist, value);
+          static_cast<In<keyT, valueT> *>(successor)->prepare_send(keylist, value);
         }
       }
     }
@@ -601,9 +601,9 @@ namespace ttg {
       for (auto &&successor : this->successors()) {
         assert(successor->get_type() != TerminalBase::Type::Write);
         if (successor->get_type() == TerminalBase::Type::Read) {
-          return static_cast<In<keyT, std::add_const_t<valueT>> *>(successor)->prepare_send(value);
+          static_cast<In<keyT, std::add_const_t<valueT>> *>(successor)->prepare_send(value);
         } else if (successor->get_type() == TerminalBase::Type::Consume) {
-          return static_cast<In<keyT, valueT> *>(successor)->prepare_send(value);
+          static_cast<In<keyT, valueT> *>(successor)->prepare_send(value);
         }
       }
     }

--- a/ttg/ttg/util/meta.h
+++ b/ttg/ttg/util/meta.h
@@ -6,9 +6,6 @@
 
 #include "ttg/util/span.h"
 #include "ttg/util/typelist.h"
-#include "ttg/buffer.h"
-#include "ttg/ptr.h"
-#include "ttg/devicescratch.h"
 
 namespace ttg {
 
@@ -303,22 +300,11 @@ namespace ttg {
     { };
 
     template<typename T>
-    struct is_ptr<ttg::Ptr<T>> : std::true_type
-    { };
-
-    template<typename T>
     constexpr bool is_ptr_v = is_ptr<T>::value;
 
+    /* specialized by the implementation */
     template<typename T>
     struct is_buffer : std::false_type
-    { };
-
-    template<typename T, typename A>
-    struct is_buffer<ttg::Buffer<T, A>> : std::true_type
-    { };
-
-    template<typename T, typename A>
-    struct is_buffer<const ttg::Buffer<T, A>> : std::true_type
     { };
 
     template<typename T>
@@ -329,16 +315,14 @@ namespace ttg {
     { };
 
     template<typename T>
-    struct is_devicescratch<ttg::devicescratch<T>> : std::true_type
-    { };
-
-    template<typename T>
-    struct is_devicescratch<const ttg::devicescratch<T>> : std::true_type
-    { };
-
-    template<typename T>
     constexpr bool is_devicescratch_v = is_devicescratch<T>::value;
 
+    template<typename T>
+    struct is_const : std::is_const<T>
+    { };
+
+    template<typename T>
+    constexpr bool is_const_v = is_const<T>::value;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // typelist metafunctions


### PR DESCRIPTION
Next set of changes needed for MRA. This change set allows buffers to be empty and const and enables tasks to define a flexible set of device inputs using `ttg::device::Input`, which is a vector of buffers internals provided by the backend implementation.