### PR TITLE
Pass the Execution Space as TT template parameter

### DIFF
--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -575,7 +575,7 @@ class SpMM25D {
   /// 3-D process grid only
   template<ttg::ExecutionSpace Space_>
   class MultiplyAdd : public TT<Key<3>, std::tuple<Out<Key<2>, Blk>, Out<Key<3>, Blk>>, MultiplyAdd<Space_>,
-                                ttg::typelist<const Blk, const Blk, Blk>> {
+                                ttg::typelist<const Blk, const Blk, Blk>, Space_> {
     static constexpr const bool is_device_space = (Space_ != ttg::ExecutionSpace::Host);
     using task_return_type = std::conditional_t<is_device_space, ttg::device::Task, void>;
 

--- a/ttg/ttg/madness/fwd.h
+++ b/ttg/ttg/madness/fwd.h
@@ -8,7 +8,9 @@
 
 namespace ttg_madness {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
+  template <typename keyT, typename output_terminalsT, typename derivedT,
+            typename input_valueTs = ttg::typelist<>,
+            ttg::ExecutionSpace Space = ttg::ExecutionSpace::Host>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/madness/ttg.h
+++ b/ttg/ttg/madness/ttg.h
@@ -184,8 +184,9 @@ namespace ttg_madness {
   /// values
   ///         flowing into this TT; a const type indicates nonmutating (read-only) use, nonconst type
   ///         indicates mutating use (e.g. the corresponding input can be used as scratch, moved-from, etc.)
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs>
-  class TT : public ttg::TTBase, public ::madness::WorldObject<TT<keyT, output_terminalsT, derivedT, input_valueTs>> {
+  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs, ttg::ExecutionSpace Space>
+  class TT : public ttg::TTBase, public ::madness::WorldObject<TT<keyT, output_terminalsT, derivedT, input_valueTs, Space>> {
+    static_assert(Space == ttg::ExecutionSpace::Host, "MADNESS backend only supports Host Execution Space");
     static_assert(ttg::meta::is_typelist_v<input_valueTs>,
                   "The fourth template for ttg::TT must be a ttg::typelist containing the input types");
     using input_tuple_type = ttg::meta::typelist_to_tuple_t<input_valueTs>;

--- a/ttg/ttg/make_tt.h
+++ b/ttg/ttg/make_tt.h
@@ -17,7 +17,7 @@ class CallableWrapTT
     : public TT<
           keyT, output_terminalsT,
           CallableWrapTT<funcT, returnT, funcT_receives_input_tuple, funcT_receives_outterm_tuple, space, keyT, output_terminalsT, input_valuesT...>,
-          ttg::typelist<input_valuesT...>> {
+          ttg::typelist<input_valuesT...>, space> {
   using baseT = typename CallableWrapTT::ttT;
 
   using input_values_tuple_type = typename baseT::input_values_tuple_type;
@@ -43,11 +43,6 @@ class CallableWrapTT
 #else   // TTG_HAVE_COROUTINE
       void;
 #endif  // TTG_HAVE_COROUTINE
-
-public:
-  static constexpr bool have_cuda_op = (space == ttg::ExecutionSpace::CUDA);
-  static constexpr bool have_hip_op  = (space == ttg::ExecutionSpace::HIP);
-  static constexpr bool have_level_zero_op = (space == ttg::ExecutionSpace::L0);
 
 protected:
 

--- a/ttg/ttg/parsec/fwd.h
+++ b/ttg/ttg/parsec/fwd.h
@@ -10,7 +10,9 @@ extern "C" struct parsec_context_s;
 
 namespace ttg_parsec {
 
-  template <typename keyT, typename output_terminalsT, typename derivedT, typename input_valueTs = ttg::typelist<>>
+  template <typename keyT, typename output_terminalsT, typename derivedT,
+            typename input_valueTs = ttg::typelist<>,
+            ttg::ExecutionSpace Space = ttg::ExecutionSpace::Host>
   class TT;
 
   /// \internal the OG name

--- a/ttg/ttg/parsec/task.h
+++ b/ttg/ttg/parsec/task.h
@@ -252,9 +252,9 @@ namespace ttg_parsec {
       template<ttg::ExecutionSpace Space>
       parsec_hook_return_t invoke_op() {
         if constexpr (Space == ttg::ExecutionSpace::Host) {
-          return TT::template static_op<Space>(&this->parsec_task);
+          return TT::static_op(&this->parsec_task);
         } else {
-          return TT::template device_static_op<Space>(&this->parsec_task);
+          return TT::device_static_op(&this->parsec_task);
         }
       }
 
@@ -263,7 +263,7 @@ namespace ttg_parsec {
         if constexpr (Space == ttg::ExecutionSpace::Host) {
           return PARSEC_HOOK_RETURN_DONE;
         } else {
-          return TT::template device_static_evaluate<Space>(&this->parsec_task);
+          return TT::device_static_evaluate(&this->parsec_task);
         }
       }
 
@@ -310,9 +310,9 @@ namespace ttg_parsec {
       template<ttg::ExecutionSpace Space>
       parsec_hook_return_t invoke_op() {
         if constexpr (Space == ttg::ExecutionSpace::Host) {
-          return TT::template static_op<Space>(&this->parsec_task);
+          return TT::static_op(&this->parsec_task);
         } else {
-          return TT::template device_static_op<Space>(&this->parsec_task);
+          return TT::device_static_op(&this->parsec_task);
         }
       }
 
@@ -321,7 +321,7 @@ namespace ttg_parsec {
         if constexpr (Space == ttg::ExecutionSpace::Host) {
           return PARSEC_HOOK_RETURN_DONE;
         } else {
-          return TT::template device_static_evaluate<Space>(&this->parsec_task);
+          return TT::device_static_evaluate(&this->parsec_task);
         }
       }
 

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -1493,7 +1493,7 @@ namespace ttg_parsec {
         PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);
         gpu_task->ec = parsec_task;
         gpu_task->task_type = 0; // user task
-        gpu_task->last_data_check_epoch = 0; // used internally
+        gpu_task->last_data_check_epoch = (uint64_t)-1; // used internally
         gpu_task->pushout = 0;
         gpu_task->submit = &TT::device_static_submit;
 


### PR DESCRIPTION
Defaults to Host execution so existing code is not affected. Properly set by make_tt.

We cannot query TT::derivedT for flags because at the time TT is instantiated because derivedT is incomplete at that point. For now pass the Space as template parameter. We need to find a different way if we want to have multiple implementations of a task.