### PR TITLE
Remove OpenMP dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,8 +220,6 @@ endif(MPI_FOUND)
 if (TTG_EXAMPLES)
     # TiledArray brings in BTAS AND linear algebra (BLAS++/LAPACK++)
     include(FindOrFetchTiledArray)
-    # OpenMP may also be used by some examples
-    find_package(OpenMP COMPONENTS CXX)
     # std::execution may also be used by some examples
     find_package(CXXStdExecution)
 endif (TTG_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,8 +75,8 @@ add_ttg_executable(fw-apsp floyd-warshall/floyd_warshall.cc LINK_LIBRARIES MADwo
 add_ttg_executable(helloworld helloworld/helloworld.cpp)
 add_ttg_executable(simplegenerator simplegenerator/simplegenerator.cc RUNTIMES "mad")
 
-if (OpenMP_CXX_FOUND AND TARGET std::execution)
-        add_ttg_executable(fw-apsp-df floyd-warshall/floyd_warshall_df.cc LINK_LIBRARIES OpenMP::OpenMP_CXX std::execution MADworld)
+if (TARGET std::execution)
+        add_ttg_executable(fw-apsp-df floyd-warshall/floyd_warshall_df.cc LINK_LIBRARIES std::execution MADworld)
 endif ()
 add_ttg_executable(ge ge/ge.cc SINGLERANKONLY)
 if (TARGET std::execution)

--- a/examples/floyd-warshall/floyd_warshall_df.cc
+++ b/examples/floyd-warshall/floyd_warshall_df.cc
@@ -28,8 +28,6 @@ using namespace ttg;
 #include "../blockmatrix.h"
 #include "ttg/util/bug.h"
 
-//#include <omp.h> //
-
 #include "FW-APSP/FloydIterativeKernelDF.h"        // contains the iterative kernel
 #include "FW-APSP/FloydRecursiveSerialKernelDF.h"  // contains the recursive but serial kernels
 // #include "FloydRecursiveParallelKernel.h" // contains the recursive and parallel kernels


### PR DESCRIPTION
No code is actually using OpenMP. Some examples still have OpenMP commented out. I'll leave it there for historical reasons.