### PR TITLE
Hotfix: reference global make_executable

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -4339,7 +4339,7 @@ namespace ttg_parsec {
     void make_executable() override {
       world.impl().register_tt_profiling(this);
       register_static_op_function();
-      ttg::TTBase::make_executable();
+      ::ttg::TTBase::make_executable();
     }
 
     /// keymap accessor


### PR DESCRIPTION
Needed to fix build with CUDA.