### PR TITLE
Receive into device

### DIFF
--- a/ttg/ttg/buffer.h
+++ b/ttg/ttg/buffer.h
@@ -71,10 +71,8 @@ namespace madness {
       : m_fn(fn)
       { }
 
-      /// Stores (counts) data into the memory buffer.
 
-      /// The function only appears (due to \c enable_if) if \c T is
-      /// serializable.
+      /// Apply function to ttg::Buffer.
       /// \tparam T Type of the data to be stored (counted).
       /// \param[in] t Pointer to the data to be stored (counted).
       /// \param[in] n Size of data to be stored (counted).

--- a/ttg/ttg/device/device.h
+++ b/ttg/ttg/device/device.h
@@ -10,6 +10,10 @@
 
 namespace ttg::device {
 
+
+  /* fwd-decl */
+  inline int num_devices();
+
   /// Represents a device in a specific execution space
   class Device {
     int m_id = 0;
@@ -52,8 +56,20 @@ namespace ttg::device {
       return (m_space == ttg::ExecutionSpace::Invalid);
     }
 
+    /* next device, cycling through all devices */
+    Device cycle() const {
+      if (m_space == ttg::ExecutionSpace::Host) {
+        return {};
+      }
+      return {(m_id + 1) % num_devices(), m_space};
+    }
+
     static Device host() {
       return {};
+    }
+
+    bool operator==(const Device& other) const {
+      return m_id == other.m_id && m_space == other.m_space;
     }
   };
 } // namespace ttg::device

--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -2933,7 +2933,11 @@ namespace ttg_parsec {
           /* handle any iovecs contained in it */
           write_header_fn();
           detail::foreach_parsec_data(value, [&](parsec_data_t *data){
-            handle_iovec_fn(ttg::iovec{data->nb_elts, data->device_copies[data->owner_device]->device_private});
+            auto device = data->owner_device;
+            if (!world.impl().mpi_support(Space)) {
+              device = 0;
+            }
+            handle_iovec_fn(ttg::iovec{data->nb_elts, data->device_copies[device]->device_private});
           });
         }
 
@@ -3110,8 +3114,12 @@ namespace ttg_parsec {
           memregs.reserve(num_iovs);
           write_iov_header();
           detail::foreach_parsec_data(value, [&](parsec_data_t *data){
+            auto device = data->owner_device;
+            if (!world.impl().mpi_support(Space)) {
+              device = 0;
+            }
             handle_iov_fn(ttg::iovec{data->nb_elts,
-                                     data->device_copies[data->owner_device]->device_private});
+                                     data->device_copies[device]->device_private});
           });
         }
 


### PR DESCRIPTION
We already supported sending from the device. This PR adds support for allocating device buffer space and receiving directly into the device. We do that if we can detect directly whether device memory is supported (OMPI) or if the user tells us that it's safe (`TTG_FORCE_DEVICE_COMM=1`, e.g., with Cray MPICH). 