### PR TITLE
Fixes for POTRF

### DIFF
--- a/examples/potrf/potrf.h
+++ b/examples/potrf/potrf.h
@@ -686,10 +686,20 @@ namespace potrf {
      */
     auto devmap1 = [&](const Key1& key) { return (key[0] / A.P()) % ttg::device::num_devices(); };
 
-    auto devmap2a = [&](const Key2& key) { return (key[0] / A.P()) % ttg::device::num_devices(); };
-    auto devmap2b = [&](const Key2& key) { return (key[1] / A.P()) % ttg::device::num_devices(); };
+    int num_devices = ttg::device::num_devices();
+    int gp = std::sqrt(num_devices);
+    int gq = num_devices / gp;
+    auto mapper = [&A, gp,gq,num_devices](int i){
+              auto device = (((i/A.P())%gp)*gq) + (i/A.Q())%gq;
+              return device;
+            };
 
-    auto devmap3 = [&](const Key3& key) { return (key[0] / A.P()) % ttg::device::num_devices(); };
+    auto devmap1 = [=](const Key1& key) { return mapper(key[0]); };
+
+    auto devmap2a = [=](const Key2& key) { return mapper(key[0]); };
+    auto devmap2b = [=](const Key2& key) { return mapper(key[1]); };
+
+    auto devmap3 = [=](const Key3& key) { return mapper(key[0]); };
 
     ttg::Edge<Key1, MatrixTile<T>> syrk_potrf("syrk_potrf"), disp_potrf("disp_potrf");
 

--- a/examples/potrf/testing_dpotrf.cc
+++ b/examples/potrf/testing_dpotrf.cc
@@ -37,6 +37,7 @@ int main(int argc, char **argv)
   char *opt = nullptr;
   int ret = EXIT_SUCCESS;
   int niter = 3;
+  bool print_dot = false;
 
   if( (opt = getCmdOption(argv+1, argv+argc, "-N")) != nullptr ) {
     N = M = atoi(opt);
@@ -57,6 +58,10 @@ int main(int argc, char **argv)
   if( (opt = getCmdOption(argv+1, argv+argc, "-n")) != nullptr) {
     niter = atoi(opt);
   }
+
+  /* whether to print the TTG dot */
+  print_dot = cmdOptionExists(argv+1, argv+argc, "-dot");
+
 
   bool check = !cmdOptionExists(argv+1, argv+argc, "-x");
   bool cow_hint = !cmdOptionExists(argv+1, argv+argc, "-w");
@@ -139,9 +144,11 @@ int main(int argc, char **argv)
       TTGUNUSED(connected);
 
       if (world.rank() == 0) {
-        std::cout << "==== begin dot ====\n";
-        std::cout << ttg::Dot()(init_tt.get()) << std::endl;
-        std::cout << "==== end dot ====\n";
+        if (print_dot) {
+          std::cout << "==== begin dot ====\n";
+          std::cout << ttg::Dot()(init_tt.get()) << std::endl;
+          std::cout << "==== end dot ====\n";
+        }
         beg = std::chrono::high_resolution_clock::now();
       }
 

--- a/examples/potrf/testing_dpotrf.cc
+++ b/examples/potrf/testing_dpotrf.cc
@@ -108,6 +108,16 @@ int main(int argc, char **argv)
   dcA.mat = parsec_data_allocate((size_t)dcA.super.nb_local_tiles *
                                  (size_t)dcA.super.bsiz *
                                  (size_t)parsec_datadist_getsizeoftype(dcA.super.mtype));
+
+  /* would be nice to have proper abstractions for this */
+  parsec_data_collection_t *o = &(dcA.super.super);
+  for (int devid = 1; devid < parsec_nb_devices; ++devid) {
+    auto* device = parsec_mca_device_get(devid);
+    if (device->memory_register) {
+      o->register_memory(o, device); // TODO: check device IDs
+    }
+  }
+
   parsec_data_collection_set_key((parsec_data_collection_t*)&dcA, (char*)"Matrix A");
 
   if(!check) {


### PR DESCRIPTION
- Only print the TTG DOT if requested
- Improved device mapper (@therault please check)
- Register matrix memory with PaRSEC